### PR TITLE
update to ensure single room activity only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "qwixx_game",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,6 +24,17 @@ io.on("connection", (socket) => {
  console.log(`A user connected: ${socket.id}`);
 
  socket.on("join_room", (data) => {
+  
+  //Checking if there are any rooms currently connected to. If so looping through each room and users. If user connected to a room, leave the room. Also remove the user from the room sockets object
+  if(roomSockets){
+   for(const[prevRoom, users] of Object.entries(roomSockets)){
+      if(users.includes(socket.id)){
+        socket.leave(prevRoom);
+        const index = users.indexOf(socket.id);
+        users.splice(index, 1);
+      }
+    }
+ }
   socket.join(data);
   console.log(`Socket ${socket.id} connected to room ${data}`)
 
@@ -36,6 +47,7 @@ io.on("connection", (socket) => {
   }
 
   console.log(roomSockets)
+  console.log(socket.rooms)
  });
 
  socket.on("disconnect", () => {


### PR DESCRIPTION
created a loop to go through roomSocket object - identify any rooms containing the socket.id
leave any exisiting room before joining a new room and update the roomSocket object 