### PR TITLE
40 feat/# a player can mark

### DIFF
--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -14,15 +14,15 @@ export default class Player {
     return this._name;
   }
 
-  get hasSubmittedChoice(): boolean {
+  public get hasSubmittedChoice(): boolean {
     return this._hasSubmittedChoice;
   }
 
-  resetSubmission() {
+  public resetSubmission() {
     this._hasSubmittedChoice = false;
   }
 
-  markSubmitted() {
+  public markSubmitted() {
     this._hasSubmittedChoice = true;
   }
 

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -1,13 +1,16 @@
 import qwixxBaseGameCard from "./QwixxBaseGameCard";
+import { rowColour } from "../enums/rowColours";
 export default class Player {
   private _name;
   private _gameCard: qwixxBaseGameCard;
-  private _hasSubmittedChoice = false;
+  private _hasSubmittedChoice;
+  private _submissionCount; 
 
   constructor(name: string, gameCard: qwixxBaseGameCard) {
     this._name = name;
     this._gameCard = gameCard;
     this._hasSubmittedChoice = false;
+    this._submissionCount = 0; 
   }
 
   get name(): string {
@@ -26,11 +29,23 @@ export default class Player {
     this._hasSubmittedChoice = true;
   }
 
-  //Using a getter for gameCard for now to allow quicker protoyping
-  //Likely needs refactoring in the future for looser coupling with the gameCard class
-  get gameCard(): qwixxBaseGameCard {
-    return this._gameCard;
+  public get submissionCount(): number {
+    return this._submissionCount;
   }
+
+  public markNumber(colour: rowColour, num: number) {
+   if(!this._gameCard.markNumbers(colour, num)){
+      return false
+    }
+
+    this.incrementSubmissionCount()
+    return true;
+  }
+
+  private incrementSubmissionCount() {
+    this._submissionCount ++
+  }
+
 
   serialize() {
     return this._gameCard.serialize();

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -23,6 +23,7 @@ export default class Player {
 
   public resetSubmission() {
     this._hasSubmittedChoice = false;
+    this._submissionCount = 0;
   }
 
   public markSubmitted() {
@@ -38,14 +39,9 @@ export default class Player {
       return false
     }
 
-    this.incrementSubmissionCount()
+    this._submissionCount ++
     return true;
   }
-
-  private incrementSubmissionCount() {
-    this._submissionCount ++
-  }
-
 
   serialize() {
     return this._gameCard.serialize();

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -42,7 +42,7 @@ export default class qwixxBaseGameCard {
     return this._numbers;
   }
 
-  markNumbers(row: rowColour, number: number) {
+  public markNumbers(row: rowColour, number: number) {
     if (!this._rows[row].includes(number)) {
       this._rows[row].push(number);
       return true;

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -111,6 +111,11 @@ export default class QwixxLogic {
       player.markSubmitted();
     }
 
+    //TODO:Half implemented as need to think about how to handle penalties.
+    if(player === this.currentPlayer){
+      player.markSubmitted();
+    }
+
     this.checkPlayersSubmission();
 
     return this.serialize();

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -73,6 +73,10 @@ export default class QwixxLogic {
         throw new Error("Invalid colour.");
     }
 
+    if(num < 2 || num > 12){
+      throw new Error("Dice number is out of range.")
+    }
+
     const player = this._playersArray.find(
       (player) => player.name === playerName
     );

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -74,13 +74,6 @@ export default class QwixxLogic {
       throw new Error("Player not found.");
     }
 
-    // if (player === this.currentPlayer && player.submissionCount === 2) {
-    //   throw new Error("Player already marked a number.");
-    // }
-
-    // if (player !== this.currentPlayer && player.submissionCount === 1) {
-    //   throw new Error("Player already marked a number.");
-    // }
     if (player.hasSubmittedChoice){
       throw new Error("Player already marked a number.")
     }

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -75,7 +75,7 @@ export default class QwixxLogic {
     }
 
     if (player.hasSubmittedChoice){
-      throw new Error("Player already marked a number.")
+      throw new Error("Player already finished their turn.")
     }
 
     if (!player.markNumber(colourToMark, num)) {
@@ -89,11 +89,7 @@ export default class QwixxLogic {
       player.markSubmitted();
     }
 
-
-    if (this.haveAllPlayersSubmitted()) {
-      this.resetAllPlayersSubmission();
-      this.nextTurn();
-    }
+    this.checkPlayersSubmission();
 
     return this.serialize();
   }
@@ -108,17 +104,23 @@ export default class QwixxLogic {
     }
 
     if (player.hasSubmittedChoice){
-      throw new Error("Player already ended their turn.")
+      throw new Error("Player already finished their turn.")
     }
 
-    player.markSubmitted();
+    if(player !== this.currentPlayer){
+      player.markSubmitted();
+    }
 
-    if (this.haveAllPlayersSubmitted()) {
+    this.checkPlayersSubmission();
+
+    return this.serialize();
+  }
+
+  private checkPlayersSubmission(){
+    if (this.haveAllPlayersSubmitted()){
       this.resetAllPlayersSubmission();
       this.nextTurn();
     }
-
-    return this.serialize();
   }
   // private get players() {
   //   return this._playersArray;

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -21,7 +21,7 @@ export default class QwixxLogic {
     return this._dice.rollAllDice();
   }
 
-  private get currentPlayer() {
+  private get activePlayer() {
     return this._playersArray[this._currentTurnIndex];
   }
 
@@ -41,6 +41,13 @@ export default class QwixxLogic {
 
   private haveAllPlayersSubmitted(): boolean {
     return this._playersArray.every((player) => player.hasSubmittedChoice);
+  }
+ 
+  private processPlayersSubmission(){
+    if (this.haveAllPlayersSubmitted()){
+      this.resetAllPlayersSubmission();
+      this.nextTurn();
+    }
   }
 
   public makeMove(playerName: string, row: string, num: number) {
@@ -83,13 +90,13 @@ export default class QwixxLogic {
     }
 
     if (
-      (player === this.currentPlayer && player.submissionCount === 2) ||
-      (player !== this.currentPlayer && player.submissionCount === 1)
+      (player === this.activePlayer && player.submissionCount === 2) ||
+      (player !== this.activePlayer && player.submissionCount === 1)
     ) {
       player.markSubmitted();
     }
 
-    this.checkPlayersSubmission();
+    this.processPlayersSubmission();
 
     return this.serialize();
   }
@@ -107,26 +114,19 @@ export default class QwixxLogic {
       throw new Error("Player already finished their turn.")
     }
 
-    if(player !== this.currentPlayer){
+    if(player !== this.activePlayer){
       player.markSubmitted();
     }
 
-    //TODO:Half implemented as need to think about how to handle penalties.
-    if(player === this.currentPlayer){
+    if(player === this.activePlayer){
       player.markSubmitted();
     }
-
-    this.checkPlayersSubmission();
+    
+    this.processPlayersSubmission();
 
     return this.serialize();
   }
 
-  private checkPlayersSubmission(){
-    if (this.haveAllPlayersSubmitted()){
-      this.resetAllPlayersSubmission();
-      this.nextTurn();
-    }
-  }
   // private get players() {
   //   return this._playersArray;
   // }
@@ -140,7 +140,7 @@ export default class QwixxLogic {
     return {
       players: serializedPlayers,
       dice: this._dice.serialize(),
-      activePlayer: this.currentPlayer.name,
+      activePlayer: this.activePlayer.name,
     };
   }
 }

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -44,10 +44,10 @@ export default class QwixxLogic {
   }
 
   public makeMove(playerName: string, row: string, num: number) {
-    if(!this.hasRolled){
-      throw new Error("Dice hasn't been rolled yet.")
+    if (!this.hasRolled) {
+      throw new Error("Dice hasn't been rolled yet.");
     }
-    
+
     let colourToMark: rowColour;
     switch (row.toLowerCase()) {
       case "red":
@@ -66,19 +66,35 @@ export default class QwixxLogic {
         throw new Error("Invalid colour.");
     }
 
-    const player = this._playersArray.find(player => player.name === playerName);
+    const player = this._playersArray.find(
+      (player) => player.name === playerName
+    );
 
-    if(!player){
+    if (!player) {
       throw new Error("Player not found.");
     }
 
-    if(!player?.gameCard.markNumbers(colourToMark, num)){
+    if (player === this.currentPlayer && player.submissionCount === 2) {
+      throw new Error("Player already marked a number.");
+    }
+
+    if (player !== this.currentPlayer && player.submissionCount === 1) {
+      throw new Error("Player already marked a number.");
+    }
+
+    if (!player.markNumber(colourToMark, num)) {
       throw new Error("Invalid move.");
     }
-    
-    player.markSubmitted();
 
-    if(this.haveAllPlayersSubmitted()){
+    if (
+      (player === this.currentPlayer && player.submissionCount === 2) ||
+      (player !== this.currentPlayer && player.submissionCount === 1)
+    ) {
+      player.markSubmitted();
+    }
+
+
+    if (this.haveAllPlayersSubmitted()) {
       this.resetAllPlayersSubmission();
       this.nextTurn();
     }

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -98,6 +98,28 @@ export default class QwixxLogic {
     return this.serialize();
   }
 
+  public endTurn(playerName: string){
+     const player = this._playersArray.find(
+      (player) => player.name === playerName
+    );
+
+    if (!player) {
+      throw new Error("Player not found.");
+    }
+
+    if (player.hasSubmittedChoice){
+      throw new Error("Player already ended their turn.")
+    }
+
+    player.markSubmitted();
+
+    if (this.haveAllPlayersSubmitted()) {
+      this.resetAllPlayersSubmission();
+      this.nextTurn();
+    }
+
+    return this.serialize();
+  }
   // private get players() {
   //   return this._playersArray;
   // }

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -74,12 +74,15 @@ export default class QwixxLogic {
       throw new Error("Player not found.");
     }
 
-    if (player === this.currentPlayer && player.submissionCount === 2) {
-      throw new Error("Player already marked a number.");
-    }
+    // if (player === this.currentPlayer && player.submissionCount === 2) {
+    //   throw new Error("Player already marked a number.");
+    // }
 
-    if (player !== this.currentPlayer && player.submissionCount === 1) {
-      throw new Error("Player already marked a number.");
+    // if (player !== this.currentPlayer && player.submissionCount === 1) {
+    //   throw new Error("Player already marked a number.");
+    // }
+    if (player.hasSubmittedChoice){
+      throw new Error("Player already marked a number.")
     }
 
     if (!player.markNumber(colourToMark, num)) {

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -183,19 +183,26 @@ export default function initializeSocketHandler(io: Server) {
     });
 
     socket.on("mark_numbers", ({ lobbyId, userId, playerChoice }) => {
+      if(!lobbyId || !userId || !playerChoice){
+        //TODO: Socket event for errors
+        console.error("Missing data");
+      }
+      
       const gameLogic = lobbiesMap[lobbyId].gameLogic;
 
-      if (gameLogic && gameLogic.hasRolled) {
-        if (playerChoice) {
-          const { row: rowColour, num } = playerChoice;
-          const updatedGameState = gameLogic.makeMove(userId, rowColour, num);
-
-          const responseData = { gameState: updatedGameState };
-
-          io.to(lobbyId).emit("update_markedNumbers", responseData);
-          console.log("Updated game state:", updatedGameState);
-        }
+      if (!gameLogic){
+        //TODO: Socket event for errors
+        console.error("Game doesn't exist. Has it been instantiated yet?")
       }
+
+      
+      const { row: rowColour, num } = playerChoice;
+      const updatedGameState = gameLogic?.makeMove(userId, rowColour, num);
+
+      const responseData = { gameState: updatedGameState };
+
+      io.to(lobbyId).emit("update_markedNumbers", responseData);
+      console.log("Updated game state:", updatedGameState);
 
       //if (gameLogic?.haveAllPlayersSubmitted()) {
       //gameLogic.resetAllPlayersSubmission();

--- a/server/src/tests/models/InitializePlayer.test.ts
+++ b/server/src/tests/models/InitializePlayer.test.ts
@@ -1,10 +1,10 @@
 import { initializePlayers } from "../../models/InitializePlayer";
 import qwixxBaseGameCard from "../../models/QwixxBaseGameCard";
 
-const mockGameCard1 = new qwixxBaseGameCard;
-const mockGameCard2 = new qwixxBaseGameCard;;
-const mockGameCard3 = new qwixxBaseGameCard;;
-const mockGameCard4 = new qwixxBaseGameCard;;
+const mockGameCard1 = new qwixxBaseGameCard();
+const mockGameCard2 = new qwixxBaseGameCard();
+const mockGameCard3 = new qwixxBaseGameCard();
+const mockGameCard4 = new qwixxBaseGameCard();
 
 describe("initializePlayers tests", () => {
   test("given 1 player name, it returns an error", () => {
@@ -43,10 +43,24 @@ describe("initializePlayers tests", () => {
     const result = initializePlayers(mockPlayerNames, mockGameCards);
     expect(result.length).toBe(4);
     for (let i = 0; i < result.length; i++) {
-      const playerName = result[i];
-      expect(playerName).toBeDefined();
-      expect(playerName.name).toBe(`player${i + 1}`);
-      expect(playerName.gameCard instanceof qwixxBaseGameCard).toBe(true);
+      const player = result[i];
+      expect(player).toBeDefined();
+      expect(player.name).toBe(`player${i + 1}`);
+      expect(player.serialize()).toEqual({
+        isLocked: {
+          blue: false,
+          green: false,
+          red: false,
+          yellow: false,
+        },
+        penalties: 0,
+        rows: {
+          blue: [],
+          green: [],
+          red: [],
+          yellow: [],
+        },
+      });
     }
   });
 });

--- a/server/src/tests/models/PlayerClass.unit.test.ts
+++ b/server/src/tests/models/PlayerClass.unit.test.ts
@@ -21,4 +21,16 @@ describe("Player Class tests", () => {
     testPlayer.markNumber(rowColour.Red,2);
     expect(testPlayer.submissionCount).toBe(1);
   })
+
+  test("submission count should return to 0 after markSubmitted() call", () => {
+    (mockGameCard.markNumbers! as jest.Mock).mockReturnValue(true);
+    const testPlayer = new Player("testPlayer", mockGameCard as qwixxBaseGameCard);
+
+    testPlayer.markNumber(rowColour.Red, 2);
+    testPlayer.markNumber(rowColour.Red, 3);
+    expect(testPlayer.submissionCount).toBe(2);
+
+    testPlayer.resetSubmission();
+    expect(testPlayer.submissionCount).toBe(0);
+  })
 });

--- a/server/src/tests/models/PlayerClass.unit.test.ts
+++ b/server/src/tests/models/PlayerClass.unit.test.ts
@@ -6,25 +6,26 @@ const mockGameCard: Partial<qwixxBaseGameCard> = {
   markNumbers: jest.fn(),
 };
 
-describe("Player Class tests", () => {
-  it("Should take a name and be able to return it", () => {
-    const testPlayer = new Player("testPlayer", mockGameCard as qwixxBaseGameCard);
+let testPlayer: Player;
 
+describe("Player Class tests", () => {
+  beforeEach(() => {
+    testPlayer = new Player("testPlayer", mockGameCard as qwixxBaseGameCard);
+  });
+
+  it("Should take a name and be able to return it", () => {
     expect(testPlayer.name).toEqual("testPlayer");
   });
 
   test("submission count should increment when incrementSubmissionCount is called", () => {
     (mockGameCard.markNumbers! as jest.Mock).mockReturnValue(true);
    
-    const testPlayer = new Player("testPlayer", mockGameCard as qwixxBaseGameCard);
-    
     testPlayer.markNumber(rowColour.Red,2);
     expect(testPlayer.submissionCount).toBe(1);
   })
 
   test("submission count should return to 0 after markSubmitted() call", () => {
     (mockGameCard.markNumbers! as jest.Mock).mockReturnValue(true);
-    const testPlayer = new Player("testPlayer", mockGameCard as qwixxBaseGameCard);
 
     testPlayer.markNumber(rowColour.Red, 2);
     testPlayer.markNumber(rowColour.Red, 3);
@@ -32,5 +33,13 @@ describe("Player Class tests", () => {
 
     testPlayer.resetSubmission();
     expect(testPlayer.submissionCount).toBe(0);
+  })
+
+  test("markSubmitted should set hasSubmittedChoice state", () => {
+    expect(testPlayer.hasSubmittedChoice).toBeFalsy();
+
+    testPlayer.markSubmitted();
+
+    expect(testPlayer.hasSubmittedChoice).toBeTruthy();
   })
 });

--- a/server/src/tests/models/PlayerClass.unit.test.ts
+++ b/server/src/tests/models/PlayerClass.unit.test.ts
@@ -1,7 +1,9 @@
+import { rowColour } from "../../enums/rowColours";
 import Player from "../../models/PlayerClass";
 import qwixxBaseGameCard from "../../models/QwixxBaseGameCard";
 
 const mockGameCard: Partial<qwixxBaseGameCard> = {
+  markNumbers: jest.fn(),
 };
 
 describe("Player Class tests", () => {
@@ -11,9 +13,12 @@ describe("Player Class tests", () => {
     expect(testPlayer.name).toEqual("testPlayer");
   });
 
-  it("Should take a score card in its constructor and be able to return it", () => {
+  test("submission count should increment when incrementSubmissionCount is called", () => {
+    (mockGameCard.markNumbers! as jest.Mock).mockReturnValue(true);
+   
     const testPlayer = new Player("testPlayer", mockGameCard as qwixxBaseGameCard);
-    console.log(testPlayer.gameCard)
-    expect(testPlayer.gameCard).toEqual(mockGameCard);
-  });
+    
+    testPlayer.markNumber(rowColour.Red,2);
+    expect(testPlayer.submissionCount).toBe(1);
+  })
 });

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -33,8 +33,7 @@ describe("Qwixx Logic integration tests:", () => {
   // });
 
   it("should make a move and return the correct result", () => {
-    const testGame = new QwixxLogic(mockPlayersArray, mockDice);
-
+    testGame.rollDice(); 
     const gameState = testGame.makeMove("test-player1", "red", 1);
     if (typeof gameState === "object") {
       expect(gameState.players).toHaveProperty("test-player1");
@@ -53,18 +52,37 @@ describe("Qwixx Logic integration tests:", () => {
     }
   });
 
+  test("current player can only mark a maximum of 2 numbers", () => {
+    testGame.rollDice();
+    testGame.makeMove("test-player1", "red", 1);
+    testGame.makeMove("test-player1", "red", 2);
+
+    expect(() => {testGame.makeMove("test-player1", "red", 3)}).toThrow("Player already marked a number");
+  })
+
+  test("non current player can only mark a maximum of 1 number", () => {
+   testGame.rollDice();
+   testGame.makeMove("test-player2", "red", 1);
+
+   expect(() => {testGame.makeMove("test-player2", "red", 2)}).toThrow("Player already marked a number");
+  })
+
   // it.skip("should updated hasSubmitted when a player makes a move", () => {
   //   testGame.makeMove("test-player1", "red", 1);
   //   expect(testGame.players[0].hasSubmittedChoice).toBe(true);
   // });
 
   test("when all players have submitted a move, it should go to the next turn by making the next player the current player", () => {
+    testGame.rollDice();
     const initialGameState = testGame.serialize();
 
     expect(initialGameState.activePlayer).toBe('test-player1');
 
     const firstMoveState = testGame.makeMove("test-player1", "red", 1);
     expect(firstMoveState.activePlayer).toBe("test-player1");
+
+    const secondMoveState = testGame.makeMove("test-player1", "red", 2);
+    expect(secondMoveState.activePlayer).toBe("test-player1");
 
     const finalMoveState = testGame.makeMove("test-player2", "blue", 3);
     expect(finalMoveState.activePlayer).toBe("test-player2");
@@ -91,12 +109,14 @@ describe("Qwixx Logic integration tests:", () => {
   //   });
 
   it("should throw an error if the player isn't found when making a move", () => {
+    testGame.rollDice();
     expect(() => {
       testGame.makeMove("test-player3", "red", 1);
     }).toThrow("Player not found");
   });
 
   it("should throw an error if colour doesn't exist in rowColour enum", () => {
+    testGame.rollDice();
     expect(() => {
       testGame.makeMove("test-player1", "orange", 1);
     }).toThrow("Invalid colour");

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -145,4 +145,10 @@ describe("Qwixx Logic integration tests:", () => {
     testGame.endTurn("test-player2");
     expect(mockPlayer2.hasSubmittedChoice).toBeTruthy(); 
   })
+
+  test("current player can end their turn without submitting a move", () => {
+    testGame.rollDice();
+    testGame.endTurn("test-player1");
+    expect(mockPlayer1.hasSubmittedChoice).toBeTruthy();
+  })
 });

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -25,15 +25,14 @@ describe("Qwixx Logic integration tests:", () => {
     testGame = new QwixxLogic(mockPlayersArray, mockDice);
   });
 
-  // it.skip("should return all players", () => {
-  //   expect(testGame.players.length).toBe(2);
-  //   testGame.players.forEach((player) => {
-  //     expect(player.gameCard instanceof qwixxBaseGameCard).toBe(true);
-  //   });
-  // });
+  test("making a move before rolling dice throws an error", () => {
+    expect(() => testGame.makeMove("test-player1", "red", 2)).toThrow(
+      "Dice hasn't been rolled yet."
+    );
+  });
 
   it("should make a move and return the correct result", () => {
-    testGame.rollDice(); 
+    testGame.rollDice();
     const gameState = testGame.makeMove("test-player1", "red", 1);
     if (typeof gameState === "object") {
       expect(gameState.players).toHaveProperty("test-player1");
@@ -57,15 +56,19 @@ describe("Qwixx Logic integration tests:", () => {
     testGame.makeMove("test-player1", "red", 1);
     testGame.makeMove("test-player1", "red", 2);
 
-    expect(() => {testGame.makeMove("test-player1", "red", 3)}).toThrow("Player already marked a number");
-  })
+    expect(() => {
+      testGame.makeMove("test-player1", "red", 3);
+    }).toThrow("Player already marked a number");
+  });
 
   test("non current player can only mark a maximum of 1 number", () => {
-   testGame.rollDice();
-   testGame.makeMove("test-player2", "red", 1);
+    testGame.rollDice();
+    testGame.makeMove("test-player2", "red", 1);
 
-   expect(() => {testGame.makeMove("test-player2", "red", 2)}).toThrow("Player already marked a number");
-  })
+    expect(() => {
+      testGame.makeMove("test-player2", "red", 2);
+    }).toThrow("Player already marked a number");
+  });
 
   // it.skip("should updated hasSubmitted when a player makes a move", () => {
   //   testGame.makeMove("test-player1", "red", 1);
@@ -76,7 +79,7 @@ describe("Qwixx Logic integration tests:", () => {
     testGame.rollDice();
     const initialGameState = testGame.serialize();
 
-    expect(initialGameState.activePlayer).toBe('test-player1');
+    expect(initialGameState.activePlayer).toBe("test-player1");
 
     const firstMoveState = testGame.makeMove("test-player1", "red", 1);
     expect(firstMoveState.activePlayer).toBe("test-player1");
@@ -86,7 +89,7 @@ describe("Qwixx Logic integration tests:", () => {
 
     const finalMoveState = testGame.makeMove("test-player2", "blue", 3);
     expect(finalMoveState.activePlayer).toBe("test-player2");
-  })
+  });
   //Maybe should break this test down into smaller parts.
   // it.skip("should reset players submission and go to the next turn when every player has made a move", () => {
   //   const resetSpy = jest.spyOn(testGame, "resetAllPlayersSubmission");
@@ -95,12 +98,12 @@ describe("Qwixx Logic integration tests:", () => {
   //   expect(testGame.currentPlayer).toBe(mockPlayer1);
 
   //   testGame.makeMove("test-player1", "red", 1);
-  
+
   //   expect(resetSpy).not.toHaveBeenCalled();
   //   expect(nextTurnSpy).not.toHaveBeenCalled();
 
   //   const gameState = testGame.makeMove("test-player2", "blue", 3);
-   
+
   //   expect(resetSpy).toHaveBeenCalled();
   //   expect(nextTurnSpy).toHaveBeenCalled();
 

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -67,7 +67,7 @@ describe("Qwixx Logic integration tests:", () => {
 
     expect(() => {
       testGame.makeMove("test-player1", "red", 4);
-    }).toThrow("Player already marked a number");
+    }).toThrow("Player already finished their turn");
   });
 
   test("current player's hasSubmittedChoice is updated after submitting 2 moves", () => {
@@ -92,7 +92,7 @@ describe("Qwixx Logic integration tests:", () => {
 
     expect(() => {
       testGame.makeMove("test-player2", "red", 3);
-    }).toThrow("Player already marked a number");
+    }).toThrow("Player already finished their turn");
   });
 
   test("non-current player's hasSubmittedChoice is updated after submitting 1 move", () => {

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -51,29 +51,56 @@ describe("Qwixx Logic integration tests:", () => {
     }
   });
 
-  test("current player can only mark a maximum of 2 numbers", () => {
+  test("current player can submit up to 2 moves", () => {
     testGame.rollDice();
-    testGame.makeMove("test-player1", "red", 1);
     testGame.makeMove("test-player1", "red", 2);
+    expect(mockPlayer1.submissionCount).toBe(1);
 
-    expect(() => {
-      testGame.makeMove("test-player1", "red", 3);
-    }).toThrow("Player already marked a number");
+    testGame.makeMove("test-player1", "red", 3);
+    expect(mockPlayer1.submissionCount).toBe(2);
   });
 
-  test("non current player can only mark a maximum of 1 number", () => {
+  test("current player can't submit more than 2 moves", () => {
     testGame.rollDice();
-    testGame.makeMove("test-player2", "red", 1);
+    testGame.makeMove("test-player1", "red", 2);
+    testGame.makeMove("test-player1", "red", 3);
 
     expect(() => {
-      testGame.makeMove("test-player2", "red", 2);
+      testGame.makeMove("test-player1", "red", 4);
     }).toThrow("Player already marked a number");
   });
 
-  // it.skip("should updated hasSubmitted when a player makes a move", () => {
-  //   testGame.makeMove("test-player1", "red", 1);
-  //   expect(testGame.players[0].hasSubmittedChoice).toBe(true);
-  // });
+  test("current player's hasSubmittedChoice is updated after submitting 2 moves", () => {
+    testGame.rollDice();
+
+    testGame.makeMove("test-player1", "red", 1);
+    expect(mockPlayer1.hasSubmittedChoice).toBe(false);
+
+    testGame.makeMove("test-player1", "red", 2);
+    expect(mockPlayer1.hasSubmittedChoice).toBe(true);
+  });
+
+  test("non-current player can submit up to 1 move", () => {
+    testGame.rollDice();
+    testGame.makeMove("test-player2", "red", 2);
+    expect(mockPlayer2.submissionCount).toBe(1);
+  });
+
+  test("non-current player can't submit more than 1 moves", () => {
+    testGame.rollDice();
+    testGame.makeMove("test-player2", "red", 2);
+
+    expect(() => {
+      testGame.makeMove("test-player2", "red", 3);
+    }).toThrow("Player already marked a number");
+  });
+
+  test("non-current player's hasSubmittedChoice is updated after submitting 1 move", () => {
+    testGame.rollDice();
+
+    testGame.makeMove("test-player2", "red", 1);
+    expect(mockPlayer2.hasSubmittedChoice).toBe(true);
+  });
 
   test("when all players have submitted a move, it should go to the next turn by making the next player the current player", () => {
     testGame.rollDice();
@@ -90,26 +117,6 @@ describe("Qwixx Logic integration tests:", () => {
     const finalMoveState = testGame.makeMove("test-player2", "blue", 3);
     expect(finalMoveState.activePlayer).toBe("test-player2");
   });
-  //Maybe should break this test down into smaller parts.
-  // it.skip("should reset players submission and go to the next turn when every player has made a move", () => {
-  //   const resetSpy = jest.spyOn(testGame, "resetAllPlayersSubmission");
-  //   const nextTurnSpy = jest.spyOn(testGame, "nextTurn");
-
-  //   expect(testGame.currentPlayer).toBe(mockPlayer1);
-
-  //   testGame.makeMove("test-player1", "red", 1);
-
-  //   expect(resetSpy).not.toHaveBeenCalled();
-  //   expect(nextTurnSpy).not.toHaveBeenCalled();
-
-  //   const gameState = testGame.makeMove("test-player2", "blue", 3);
-
-  //   expect(resetSpy).toHaveBeenCalled();
-  //   expect(nextTurnSpy).toHaveBeenCalled();
-
-  //   expect(testGame.hasRolled).toBe(false);
-  //   expect(testGame.currentPlayer).toBe(mockPlayer2);
-  //   });
 
   it("should throw an error if the player isn't found when making a move", () => {
     testGame.rollDice();
@@ -132,21 +139,4 @@ describe("Qwixx Logic integration tests:", () => {
       expect(value).toBeLessThanOrEqual(6);
     });
   });
-
-  //hasRolled() should potentially be a private method.
-  // it.skip("should update the hasRolled property to true once a dice has been rolled", () => {
-  //   testGame.rollDice();
-  //   expect(testGame.hasRolled).toBe(true);
-  // });
-
-  //currentPlayer should potentially be a private method.
-  // it.skip("should have an active player, which is the first player players array", () => {
-  //   expect(testGame.currentPlayer.name).toBe("test-player1");
-  // });
-
-  //nextTurn() should be a private method
-  // it.skip("should change active player to the next player at end of the turn", () => {
-  //   testGame.nextTurn();
-  //   expect(testGame.currentPlayer.name).toBe("test-player2");
-  // });
 });

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -139,4 +139,10 @@ describe("Qwixx Logic integration tests:", () => {
       expect(value).toBeLessThanOrEqual(6);
     });
   });
+
+  test("non-current player can end their turn without submitting a move", () => {
+    testGame.rollDice();
+    testGame.endTurn("test-player2");
+    expect(mockPlayer2.hasSubmittedChoice).toBeTruthy(); 
+  })
 });

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -102,7 +102,7 @@ describe("Qwixx Logic integration tests:", () => {
     expect(mockPlayer2.hasSubmittedChoice).toBe(true);
   });
 
-  test("when all players have submitted a move, it should go to the next turn by making the next player the current player", () => {
+  test("when all players have submitted a move, it should go to the next turn by making the next player the active player", () => {
     testGame.rollDice();
     const initialGameState = testGame.serialize();
 
@@ -116,6 +116,24 @@ describe("Qwixx Logic integration tests:", () => {
 
     const finalMoveState = testGame.makeMove("test-player2", "blue", 3);
     expect(finalMoveState.activePlayer).toBe("test-player2");
+  });
+
+  test("when the game goes to the next turn, all players' submission state is reset", () => {
+    testGame.rollDice();
+
+    testGame.makeMove("test-player1", "red", 2);
+    testGame.makeMove("test-player2", "blue", 3);
+
+    expect(mockPlayer1.submissionCount).toBe(1);
+    expect(mockPlayer2.submissionCount).toBe(1);
+    expect(mockPlayer2.hasSubmittedChoice).toBeTruthy();
+
+    testGame.makeMove("test-player1", "red", 3);
+
+    expect(mockPlayer1.hasSubmittedChoice).toBeFalsy();
+    expect(mockPlayer1.submissionCount).toBe(0);
+    expect(mockPlayer2.hasSubmittedChoice).toBeFalsy();
+    expect(mockPlayer2.submissionCount).toBe(0);
   });
 
   it("should throw an error if the player isn't found when making a move", () => {
@@ -143,12 +161,12 @@ describe("Qwixx Logic integration tests:", () => {
   test("non-current player can end their turn without submitting a move", () => {
     testGame.rollDice();
     testGame.endTurn("test-player2");
-    expect(mockPlayer2.hasSubmittedChoice).toBeTruthy(); 
-  })
+    expect(mockPlayer2.hasSubmittedChoice).toBeTruthy();
+  });
 
   test("current player can end their turn without submitting a move", () => {
     testGame.rollDice();
     testGame.endTurn("test-player1");
     expect(mockPlayer1.hasSubmittedChoice).toBeTruthy();
-  })
+  });
 });

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -33,7 +33,7 @@ describe("Qwixx Logic integration tests:", () => {
 
   it("should make a move and return the correct result", () => {
     testGame.rollDice();
-    const gameState = testGame.makeMove("test-player1", "red", 1);
+    const gameState = testGame.makeMove("test-player1", "red", 2);
     if (typeof gameState === "object") {
       expect(gameState.players).toHaveProperty("test-player1");
       expect(gameState.players).toHaveProperty("test-player2");
@@ -73,10 +73,10 @@ describe("Qwixx Logic integration tests:", () => {
   test("current player's hasSubmittedChoice is updated after submitting 2 moves", () => {
     testGame.rollDice();
 
-    testGame.makeMove("test-player1", "red", 1);
+    testGame.makeMove("test-player1", "red", 2);
     expect(mockPlayer1.hasSubmittedChoice).toBe(false);
 
-    testGame.makeMove("test-player1", "red", 2);
+    testGame.makeMove("test-player1", "red", 3);
     expect(mockPlayer1.hasSubmittedChoice).toBe(true);
   });
 
@@ -98,7 +98,7 @@ describe("Qwixx Logic integration tests:", () => {
   test("non-current player's hasSubmittedChoice is updated after submitting 1 move", () => {
     testGame.rollDice();
 
-    testGame.makeMove("test-player2", "red", 1);
+    testGame.makeMove("test-player2", "red", 2);
     expect(mockPlayer2.hasSubmittedChoice).toBe(true);
   });
 
@@ -108,10 +108,10 @@ describe("Qwixx Logic integration tests:", () => {
 
     expect(initialGameState.activePlayer).toBe("test-player1");
 
-    const firstMoveState = testGame.makeMove("test-player1", "red", 1);
+    const firstMoveState = testGame.makeMove("test-player1", "red", 2);
     expect(firstMoveState.activePlayer).toBe("test-player1");
 
-    const secondMoveState = testGame.makeMove("test-player1", "red", 2);
+    const secondMoveState = testGame.makeMove("test-player1", "red", 3);
     expect(secondMoveState.activePlayer).toBe("test-player1");
 
     const finalMoveState = testGame.makeMove("test-player2", "blue", 3);
@@ -139,7 +139,7 @@ describe("Qwixx Logic integration tests:", () => {
   it("should throw an error if the player isn't found when making a move", () => {
     testGame.rollDice();
     expect(() => {
-      testGame.makeMove("test-player3", "red", 1);
+      testGame.makeMove("test-player3", "red", 2);
     }).toThrow("Player not found");
   });
 

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -7,13 +7,16 @@ import Dice from "../../models/DiceClass";
 let mockPlayersArray: Player[];
 let mockDice: Dice;
 let testGame: QwixxLogic;
+let mockPlayer1: Player;
+let mockPlayer2: Player;
+
 describe("Qwixx Logic integration tests:", () => {
   beforeEach(() => {
     const mockgameCard1 = new qwixxBaseGameCard();
-    const mockPlayer1 = new Player("test-player1", mockgameCard1);
+    mockPlayer1 = new Player("test-player1", mockgameCard1);
 
     const mockgameCard2 = new qwixxBaseGameCard();
-    const mockPlayer2 = new Player("test-player2", mockgameCard2);
+    mockPlayer2 = new Player("test-player2", mockgameCard2);
 
     mockDice = new Dice(SixSidedDie);
 
@@ -22,12 +25,12 @@ describe("Qwixx Logic integration tests:", () => {
     testGame = new QwixxLogic(mockPlayersArray, mockDice);
   });
 
-  it("should return all players", () => {
-    expect(testGame.players.length).toBe(2);
-    testGame.players.forEach((player) => {
-      expect(player.gameCard instanceof qwixxBaseGameCard).toBe(true);
-    });
-  });
+  // it.skip("should return all players", () => {
+  //   expect(testGame.players.length).toBe(2);
+  //   testGame.players.forEach((player) => {
+  //     expect(player.gameCard instanceof qwixxBaseGameCard).toBe(true);
+  //   });
+  // });
 
   it("should make a move and return the correct result", () => {
     const testGame = new QwixxLogic(mockPlayersArray, mockDice);
@@ -50,25 +53,47 @@ describe("Qwixx Logic integration tests:", () => {
     }
   });
 
-  it("should updated hasSubmitted when a player makes a move", () => {
-    testGame.makeMove("test-player1", "red", 1);
-    expect(testGame.players[0].hasSubmittedChoice).toBe(true);
-  });
+  // it.skip("should updated hasSubmitted when a player makes a move", () => {
+  //   testGame.makeMove("test-player1", "red", 1);
+  //   expect(testGame.players[0].hasSubmittedChoice).toBe(true);
+  // });
 
-  it("should update haveAllPlayersSubmitted when every player has made a move, then reset submission and call next turn", () => {
-    const resetSpy = jest.spyOn(testGame, "resetAllPlayersSubmission");
-    const nextTurnSpy = jest.spyOn(testGame, "nextTurn");
+  test("when all players have submitted a move, it should go to the next turn by making the next player the current player", () => {
+    const initialGameState = testGame.serialize();
 
-    testGame.makeMove("test-player1", "red", 1);
-    testGame.makeMove("test-player2", "blue", 3);
-    //expect(testGame.haveAllPlayersSubmitted()).toEqual(true);
-    expect(resetSpy).toHaveBeenCalled();
-    expect(nextTurnSpy).toHaveBeenCalled();
-  });
+    expect(initialGameState.activePlayer).toBe('test-player1');
 
-  it("should return a message if the player isn't found when making a move", () => {
-    const nonPlayerResult = testGame.makeMove("test-player3", "red", 1);
-    expect(nonPlayerResult).toBe("Player not found");
+    const firstMoveState = testGame.makeMove("test-player1", "red", 1);
+    expect(firstMoveState.activePlayer).toBe("test-player1");
+
+    const finalMoveState = testGame.makeMove("test-player2", "blue", 3);
+    expect(finalMoveState.activePlayer).toBe("test-player2");
+  })
+  //Maybe should break this test down into smaller parts.
+  // it.skip("should reset players submission and go to the next turn when every player has made a move", () => {
+  //   const resetSpy = jest.spyOn(testGame, "resetAllPlayersSubmission");
+  //   const nextTurnSpy = jest.spyOn(testGame, "nextTurn");
+
+  //   expect(testGame.currentPlayer).toBe(mockPlayer1);
+
+  //   testGame.makeMove("test-player1", "red", 1);
+  
+  //   expect(resetSpy).not.toHaveBeenCalled();
+  //   expect(nextTurnSpy).not.toHaveBeenCalled();
+
+  //   const gameState = testGame.makeMove("test-player2", "blue", 3);
+   
+  //   expect(resetSpy).toHaveBeenCalled();
+  //   expect(nextTurnSpy).toHaveBeenCalled();
+
+  //   expect(testGame.hasRolled).toBe(false);
+  //   expect(testGame.currentPlayer).toBe(mockPlayer2);
+  //   });
+
+  it("should throw an error if the player isn't found when making a move", () => {
+    expect(() => {
+      testGame.makeMove("test-player3", "red", 1);
+    }).toThrow("Player not found");
   });
 
   it("should throw an error if colour doesn't exist in rowColour enum", () => {
@@ -85,17 +110,20 @@ describe("Qwixx Logic integration tests:", () => {
     });
   });
 
-  it("should update the hasRolled property to true once a dice has been rolled", () => {
-    testGame.rollDice();
-    expect(testGame.hasRolled).toBe(true);
-  });
+  //hasRolled() should potentially be a private method.
+  // it.skip("should update the hasRolled property to true once a dice has been rolled", () => {
+  //   testGame.rollDice();
+  //   expect(testGame.hasRolled).toBe(true);
+  // });
 
-  it("should have an active player, which is the first player players array", () => {
-    expect(testGame.currentPlayer.name).toBe("test-player1");
-  });
+  //currentPlayer should potentially be a private method.
+  // it.skip("should have an active player, which is the first player players array", () => {
+  //   expect(testGame.currentPlayer.name).toBe("test-player1");
+  // });
 
-  it("should change active player to the next player at end of the turn", () => {
-    testGame.nextTurn();
-    expect(testGame.currentPlayer.name).toBe("test-player2");
-  });
+  //nextTurn() should be a private method
+  // it.skip("should change active player to the next player at end of the turn", () => {
+  //   testGame.nextTurn();
+  //   expect(testGame.currentPlayer.name).toBe("test-player2");
+  // });
 });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -45,7 +45,7 @@ describe("Qwixx Logic tests", () => {
     testGame.rollDice();
     testGame.makeMove("player1", "red", 1);
     
-    expect(player1Mock.markNumber).toHaveBeenCalledWith("red", 1);
+    expect(player1Mock.markNumber).toHaveBeenCalledWith("red", 2);
     expect(player1Mock.markNumber).toHaveBeenCalledTimes(1);
   });
 
@@ -53,7 +53,7 @@ describe("Qwixx Logic tests", () => {
     const testGame = new QwixxLogic(playersArrayMock, diceMock as Dice);
     testGame.rollDice();
 
-    expect(() => testGame.makeMove("bad-player", "red", 1)).toThrow("Player not found");
+    expect(() => testGame.makeMove("bad-player", "red", 2)).toThrow("Player not found");
     // const result = testGame.makeMove("", "red", 1);
     // expect(result).toBe("Player not found");
   });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -43,7 +43,7 @@ describe("Qwixx Logic tests", () => {
     const testGame = new QwixxLogic(playersArrayMock, diceMock as Dice);
     
     testGame.rollDice();
-    testGame.makeMove("player1", "red", 1);
+    testGame.makeMove("player1", "red", 2);
     
     expect(player1Mock.markNumber).toHaveBeenCalledWith("red", 2);
     expect(player1Mock.markNumber).toHaveBeenCalledTimes(1);

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -11,13 +11,17 @@ const gameCardMock: Partial<qwixxBaseGameCard> = {
 const player1Mock: Partial<Player> = {
   name: "player1",
   gameCard: gameCardMock as qwixxBaseGameCard,
+  hasSubmittedChoice: false,
   serialize: jest.fn(),
+  markSubmitted: jest.fn(), 
 };
 
 const player2Mock: Partial<Player> = {
   name: "player2",
   gameCard: gameCardMock as qwixxBaseGameCard,
+  hasSubmittedChoice: false,
   serialize: jest.fn(),
+  markSubmitted: jest.fn(),
 };
 
 const diceMock: Partial<Dice> = {
@@ -30,26 +34,15 @@ const playersArrayMock: Player[] = [
 ];
 
 describe("Qwixx Logic tests", () => {
-  it.skip("should make a move and return the correct result", () => {
+  it("should make a move and return the correct result", () => {
     (gameCardMock.markNumbers! as jest.Mock).mockReturnValue(true);
 
     const testGame = new QwixxLogic(playersArrayMock, diceMock as Dice);
 
     const gameState = testGame.makeMove("player1", "red", 1);
-    console.log(gameState);
-    // expect(gameState).toEqual({
-    //   playerName: "player1",
-    //   row: "red",
-    //   num: 1,
-    // });
     expect(gameCardMock.markNumbers).toHaveBeenCalledWith("red", 1);
 
     const player2result = testGame.makeMove("player2", "blue", 1);
-    // expect(player2result).toEqual({
-    //   playerName: "player2",
-    //   row: "blue",
-    //   num: 1,
-    // });
     expect(gameCardMock.markNumbers).toHaveBeenCalledWith("blue", 1);
   });
 
@@ -58,4 +51,6 @@ describe("Qwixx Logic tests", () => {
     const result = testGame.makeMove("", "red", 1);
     expect(result).toBe("Player not found");
   });
+
+  test("haveAllPlayersSubmitted should be false ")
 });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -10,21 +10,24 @@ const gameCardMock: Partial<qwixxBaseGameCard> = {
 
 const player1Mock: Partial<Player> = {
   name: "player1",
-  gameCard: gameCardMock as qwixxBaseGameCard,
+  // gameCard: gameCardMock as qwixxBaseGameCard,
   hasSubmittedChoice: false,
   serialize: jest.fn(),
   markSubmitted: jest.fn(), 
+  markNumber: jest.fn(),
 };
 
 const player2Mock: Partial<Player> = {
   name: "player2",
-  gameCard: gameCardMock as qwixxBaseGameCard,
+  // gameCard: gameCardMock as qwixxBaseGameCard,
   hasSubmittedChoice: false,
   serialize: jest.fn(),
   markSubmitted: jest.fn(),
+  markNumber: jest.fn(),
 };
 
 const diceMock: Partial<Dice> = {
+  rollAllDice: jest.fn(),
   serialize: jest.fn(),
 };
 
@@ -34,23 +37,24 @@ const playersArrayMock: Player[] = [
 ];
 
 describe("Qwixx Logic tests", () => {
-  it("should make a move and return the correct result", () => {
-    (gameCardMock.markNumbers! as jest.Mock).mockReturnValue(true);
-
+  it("should call the markNumber method with correct args", () => {
+    (player1Mock.markNumber as jest.Mock).mockReturnValue(true);
+    
     const testGame = new QwixxLogic(playersArrayMock, diceMock as Dice);
-
-    const gameState = testGame.makeMove("player1", "red", 1);
-    expect(gameCardMock.markNumbers).toHaveBeenCalledWith("red", 1);
-
-    const player2result = testGame.makeMove("player2", "blue", 1);
-    expect(gameCardMock.markNumbers).toHaveBeenCalledWith("blue", 1);
+    
+    testGame.rollDice();
+    testGame.makeMove("player1", "red", 1);
+    
+    expect(player1Mock.markNumber).toHaveBeenCalledWith("red", 1);
+    expect(player1Mock.markNumber).toHaveBeenCalledTimes(1);
   });
 
-  it("should return a message if the player isn't found", () => {
+  it("should throw an error if the player isn't found", () => {
     const testGame = new QwixxLogic(playersArrayMock, diceMock as Dice);
-    const result = testGame.makeMove("", "red", 1);
-    expect(result).toBe("Player not found");
-  });
+    testGame.rollDice();
 
-  test("haveAllPlayersSubmitted should be false ")
+    expect(() => testGame.makeMove("bad-player", "red", 1)).toThrow("Player not found");
+    // const result = testGame.makeMove("", "red", 1);
+    // expect(result).toBe("Player not found");
+  });
 });


### PR DESCRIPTION
## Features
- Added a submission count state to the Player class.
- Active player can mark up to 2 numbers.
- non-active player can mark up to 1 number.
- A players submission state is automatically triggered when they've taken their turn.
- QwixxLogic class handles errors
- Errors are caught in socketHandler and emitted to the client as an "error_occured" event. 
- Added an endTurn() method that updates the submission state directly so that players can end their turn without marking a number. 

## Description
I turned a lot of QwixxLogic and Player methods into private methods which means that the tests that were written can't be used as it tests for implementation rather than behaviour. To test for behaviour, we assert on the returned data from serialize(). It works because the data includes the active player. We can also test against the player instances in the tests for properties like "submissionCount" and "hasSubmittedChoice" as those have public methods.

I then worked on limiting how many moves a player can make and I was able to use the markSubmitted()/hasSubmittedChoice that @kashida2021 wrote. The only thing I added was a "submissionCount" property to the Player class that is used to call "markSubmitted()". 

I then realised that players can end their turn without marking a number so I created a endTurn() method that calls "markSubmitted()".  