### PR TITLE
Enhancement/disable numbers after choice

### DIFF
--- a/client/src/components/GameCard/CellButton.tsx
+++ b/client/src/components/GameCard/CellButton.tsx
@@ -19,6 +19,9 @@ const CellButton: React.FC<ICellButton> = ({
 }) => {
   const [isDisabled, setIsDisabled] = useState(isClicked);
 
+  const notValid = clickAttributes === "disabled";
+
+
   const handleClick = () => {
   console.log("clicked")
   cellClick(rowColour, num);
@@ -42,7 +45,7 @@ const CellButton: React.FC<ICellButton> = ({
         <button
           className={`cell-btn ${rowColour} ${clickAttributes}`}
           aria-label="interactive-button"
-          disabled={isDisabled}
+          disabled={isDisabled || notValid}
           onClick={handleClick}
         >
           {num}

--- a/client/src/components/GameCard/GameCard.css
+++ b/client/src/components/GameCard/GameCard.css
@@ -84,6 +84,15 @@
     color: white;
   }
 
+  .cell-btn.disabled {
+    background-color: grey;
+    color: white;
+    cursor: not-allowed;
+    opacity: 0.8;
+  }
+
+
+
   
 
 

--- a/client/src/components/GameCard/Row.tsx
+++ b/client/src/components/GameCard/Row.tsx
@@ -56,7 +56,6 @@ const Row: React.FC<RowProps> = ({
         {buttonNumbers.map((num, numIndex) => {
           // const isDisabled = gameCardData[rowColour].includes(num) || locked;
           const isDisabled = gameCardData.rows[rowColour].includes(num);
-          const classAttributes = isDisabled ? "clicked" : "";
           
           let notValid = false;
 
@@ -65,6 +64,8 @@ const Row: React.FC<RowProps> = ({
           } else {
             notValid = minMarkedNumber !== undefined && num > minMarkedNumber;
           }
+
+          const classAttributes = isDisabled ? "clicked" : notValid ? "disabled" : "" ;
 
           return (
             <CellButton

--- a/client/src/components/GameCard/Row.tsx
+++ b/client/src/components/GameCard/Row.tsx
@@ -46,12 +46,25 @@ const Row: React.FC<RowProps> = ({
   // }, [gameCardData, rowColour]);
 
   const renderRow = () => {
+
+    const markedNumbers = gameCardData.rows[rowColour] || [];
+    const maxMarkedNumber = markedNumbers.length > 0 ? Math.max(...markedNumbers) : undefined
+    const minMarkedNumber = markedNumbers.length > 0 ? Math.min(...markedNumbers) : undefined
+
     return (
       <ol className={`row ${rowColour}`} aria-label={`row-${rowColour}`}>
         {buttonNumbers.map((num, numIndex) => {
           // const isDisabled = gameCardData[rowColour].includes(num) || locked;
           const isDisabled = gameCardData.rows[rowColour].includes(num);
           const classAttributes = isDisabled ? "clicked" : "";
+          
+          let notValid = false;
+
+          if(rowIndex < 2) {
+            notValid = maxMarkedNumber !== undefined && num < maxMarkedNumber;
+          } else {
+            notValid = minMarkedNumber !== undefined && num > minMarkedNumber;
+          }
 
           return (
             <CellButton

--- a/client/tests/components/GameCard/Row.test.tsx
+++ b/client/tests/components/GameCard/Row.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi} from "vitest"; // it - add later
-import { render, screen } from "@testing-library/react"; // waitFor, within add later
+import { render, screen, waitFor } from "@testing-library/react"; // waitFor, within add later
 import { userEvent } from "@testing-library/user-event";
 import React from "react";
 import Row from "../../../src/components/GameCard/Row";
@@ -131,6 +131,28 @@ describe("Row component test:", () => {
 
       expect(redButtons[4]).toBeDisabled();
     });
+
+    test("when a button is clicked the numbers below are disabled", async () => {
+      render(
+        <Row
+          rowColour={RowColour.Red}
+          numbers={numbers}
+          isOpponent={false}
+          rowIndex={0}
+          gameCardData={gameCardDataWithNumbers}
+          cellClick={mockCellClick}
+        />
+      );
+
+      const redButtons = screen.getAllByRole("button");
+      await user.click(redButtons[4]);
+
+      await waitFor(()=> {
+        expect(redButtons[3]).toHaveClass("disabled");
+        expect(redButtons[2]).toHaveClass("disabled");
+      })
+    });
+
 
     test("when the row is locked, all buttons are disabled", async () => {
       render(

--- a/client/tests/components/GameCard/Row.test.tsx
+++ b/client/tests/components/GameCard/Row.test.tsx
@@ -39,6 +39,22 @@ const gameCardDataWithNumbers: QwixxLogic['players'][string] = {
   penalties: 0,
 };
 
+const gameCardMarked: QwixxLogic['players'][string] = {
+  rows: {
+    red: [6],
+    yellow: [],
+    green: [],
+    blue: [],
+  },
+  isLocked: {
+    red: false,
+    yellow: false,
+    green: false,
+    blue: false,
+  },
+  penalties: 0,
+};
+
 const gameCardWithLockedRow: QwixxLogic['players'][string] = {
   rows: {
     red: [],
@@ -95,8 +111,8 @@ describe("Row component test:", () => {
 
 
   //IGNORE THESE TESTS FOR NOW AS THEY'RE RELATED TO LOCKING UI
-  describe.skip("Player's Card", () => {
-    test("it renders buttons with disabled attribute", () => {
+  describe("Player's Card", () => {
+    test.skip("it renders buttons with disabled attribute", () => {
       render(
         <Row
           rowColour={RowColour.Red}
@@ -114,7 +130,8 @@ describe("Row component test:", () => {
       );
       expect(disabledButtons.length).toBe(4);
     });
-    test("when a button is clicked it becomes disabled", async () => {
+
+    test.skip("when a button is clicked it becomes disabled", async () => {
       render(
         <Row
           rowColour={RowColour.Red}
@@ -139,13 +156,13 @@ describe("Row component test:", () => {
           numbers={numbers}
           isOpponent={false}
           rowIndex={0}
-          gameCardData={gameCardDataWithNumbers}
+          gameCardData={gameCardMarked}
           cellClick={mockCellClick}
         />
       );
 
       const redButtons = screen.getAllByRole("button");
-      await user.click(redButtons[4]);
+      await user.click(redButtons[6]);
 
       await waitFor(()=> {
         expect(redButtons[3]).toHaveClass("disabled");
@@ -154,7 +171,7 @@ describe("Row component test:", () => {
     });
 
 
-    test("when the row is locked, all buttons are disabled", async () => {
+    test.skip("when the row is locked, all buttons are disabled", async () => {
       render(
         <Row
           rowColour={RowColour.Red}
@@ -170,7 +187,7 @@ describe("Row component test:", () => {
       redButtons.forEach((button) => expect(button).toBeDisabled());
     });
 
-    test("when a user clicks the last number, it locks the row", async () => {
+    test.skip("when a user clicks the last number, it locks the row", async () => {
       render(
         <Row
           rowColour={RowColour.Red}


### PR DESCRIPTION
In Row component:
- added variables to check what the highest and lowest marked numbers are on a players gamecard
- then based on the row index - it will add a disable class to buttons that have a number either below the lowest number selected or above the highest number selected 
- added styling to disable the button and make it visible that the numbers are no longer valid choices 
- added test to make sure that if gamecard is updated with a selection that the numbers below or above have the disabled class