### PR TITLE
Feature/end turn results in penalty

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,7 +7,7 @@ import { socket } from "./services/socketServices";
 // import GameBoard from "../../shared/GameBoard";
 import Game from "./pages/GamePage/GamePage";
 import { QwixxLogic } from "./types/qwixxLogic";
-import { MoveAvailability} from "./types/GameCardData";
+import { MoveAvailability } from "./types/GameCardData";
 
 function App() {
   const [isConnected, setIsConnected] = useState(socket.connected);
@@ -18,7 +18,7 @@ function App() {
   const [notifications, setNotifications] = useState<string[]>([]);
   const [gameState, setGameState] = useState<QwixxLogic | null>(null);
   const [gamePath, setGamePath] = useState("");
-  const [availableMoves, setAvailableMoves] = useState<MoveAvailability>({});
+  const [availableMoves, setAvailableMoves] = useState<boolean>(false);
 
   //Need to consier if this is overkill for our app as it's only being used in one place.
   //  const handleInputChange =
@@ -92,16 +92,16 @@ function App() {
     };
 
     //const endTurn = (data: {gameState: QwixxLogic}) => {
-      //setGameState(data.gameState);
-      //console.log("turn ended", data );
+    //setGameState(data.gameState);
+    //console.log("turn ended", data );
     //}
 
-    const handleDiceRolled = (data: { dice: QwixxLogic['dice'], moveAvailability: MoveAvailability, hasRolled: boolean }) => {
+    const handleDiceRolled = (data: { diceValues: any, hasAvailableMoves: boolean, hasRolled: boolean }) => {
       setGameState((prevState) => {
         if (!prevState) {
           return {
             players: {},
-            dice: data.dice,
+            dice: data.diceValues,
             activePlayer: "",
             hasRolled: false
           };
@@ -109,17 +109,17 @@ function App() {
 
         return {
           ...prevState,
-          dice: data.dice,
+          dice: data.diceValues,
           hasRolled: data.hasRolled
         };
       });
-      setAvailableMoves(data.moveAvailability);
-      console.log("move availability after dice roll", data.moveAvailability);
+      setAvailableMoves(data.hasAvailableMoves);
+      console.log("move availability after dice roll", data.hasAvailableMoves);
       console.log("has dice been rolled", data.hasRolled);
       console.log("data after dice roll", data);
     };
 
-    const updatePenalty = (data: {responseData: QwixxLogic}) => {
+    const updatePenalty = (data: { responseData: QwixxLogic }) => {
       setGameState(data.responseData)
       console.log("penalty data", data.responseData);
     }
@@ -195,7 +195,7 @@ function App() {
                 members={members}
                 gameState={gameState}
                 availableMoves={availableMoves}
-                // setGameBoardState={setGameBoardState}
+              // setGameBoardState={setGameBoardState}
               />
             ) : (
               <div>Loading...</div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -85,8 +85,9 @@ function App() {
       console.log(data.gameState);
     };
 
-    const updateMarkedNumbers = (data: { gameState: QwixxLogic }) => {
+    const updateMarkedNumbers = (data: { gameState: QwixxLogic, moveAvailability: MoveAvailability }) => {
       setGameState(data.gameState);
+      setAvailableMoves(data.moveAvailability);
       console.log("data received from backend", data);
     };
 
@@ -111,6 +112,7 @@ function App() {
         };
       });
       setAvailableMoves(data.moveAvailability);
+      console.log("move availability after dice roll", data.moveAvailability);
     };
 
     socket.on("connect", onConnect);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { socket } from "./services/socketServices";
 // import GameBoard from "../../shared/GameBoard";
 import Game from "./pages/GamePage/GamePage";
 import { QwixxLogic } from "./types/qwixxLogic";
+import { MoveAvailability} from "./types/GameCardData";
 
 function App() {
   const [isConnected, setIsConnected] = useState(socket.connected);
@@ -17,6 +18,7 @@ function App() {
   const [notifications, setNotifications] = useState<string[]>([]);
   const [gameState, setGameState] = useState<QwixxLogic | null>(null);
   const [gamePath, setGamePath] = useState("");
+  const [availableMoves, setAvailableMoves] = useState<MoveAvailability>({});
 
   //Need to consier if this is overkill for our app as it's only being used in one place.
   //  const handleInputChange =
@@ -93,7 +95,7 @@ function App() {
       //console.log("turn ended", data );
     //}
 
-    const handleDiceRolled = (data: { dice: QwixxLogic['dice'] }) => {
+    const handleDiceRolled = (data: { dice: QwixxLogic['dice'], moveAvailability: MoveAvailability }) => {
       setGameState((prevState) => {
         if (!prevState) {
           return {
@@ -108,6 +110,7 @@ function App() {
           dice: data.dice,
         };
       });
+      setAvailableMoves(data.moveAvailability);
     };
 
     socket.on("connect", onConnect);
@@ -178,6 +181,7 @@ function App() {
                 userId={userId}
                 members={members}
                 gameState={gameState}
+                availableMoves={availableMoves}
                 // setGameBoardState={setGameBoardState}
               />
             ) : (

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -96,23 +96,27 @@ function App() {
       //console.log("turn ended", data );
     //}
 
-    const handleDiceRolled = (data: { dice: QwixxLogic['dice'], moveAvailability: MoveAvailability }) => {
+    const handleDiceRolled = (data: { dice: QwixxLogic['dice'], moveAvailability: MoveAvailability, hasRolled: boolean }) => {
       setGameState((prevState) => {
         if (!prevState) {
           return {
             players: {},
             dice: data.dice,
             activePlayer: "",
+            hasRolled: false
           };
         }
 
         return {
           ...prevState,
           dice: data.dice,
+          hasRolled: data.hasRolled
         };
       });
       setAvailableMoves(data.moveAvailability);
       console.log("move availability after dice roll", data.moveAvailability);
+      console.log("has dice been rolled", data.hasRolled);
+      console.log("data after dice roll", data);
     };
 
     socket.on("connect", onConnect);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -85,9 +85,8 @@ function App() {
       console.log(data.gameState);
     };
 
-    const updateMarkedNumbers = (data: { gameState: QwixxLogic, moveAvailability: MoveAvailability }) => {
+    const updateMarkedNumbers = (data: { gameState: QwixxLogic }) => {
       setGameState(data.gameState);
-      setAvailableMoves(data.moveAvailability);
       console.log("data received from backend", data);
     };
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -119,6 +119,11 @@ function App() {
       console.log("data after dice roll", data);
     };
 
+    const updatePenalty = (data: {responseData: QwixxLogic}) => {
+      setGameState(data.responseData)
+      console.log("penalty data", data.responseData);
+    }
+
     socket.on("connect", onConnect);
     socket.on("disconnect", onDisconnect);
     socket.on("player_joined", handlePlayerJoined);
@@ -129,6 +134,7 @@ function App() {
     socket.on("game_initialised", onGameInitialised);
     socket.on("update_markedNumbers", updateMarkedNumbers);
     socket.on("dice_rolled", handleDiceRolled);
+    socket.on("penalty_processed", updatePenalty);
     //socket.on("turn_ended", endTurn);
 
     return () => {
@@ -142,6 +148,7 @@ function App() {
       socket.off("game_initialised");
       socket.off("update_markedNumbers");
       socket.off("dice_rolled");
+      socket.off("penalty_processed");
       //socket.off("turn_ended");
     };
   }, []);

--- a/client/src/components/GameCard/GameCard.tsx
+++ b/client/src/components/GameCard/GameCard.tsx
@@ -1,6 +1,6 @@
 import Row from "./Row";
 import "./GameCard.css";
-import { ChangeEvent } from "react"; //add useState later
+//import { ChangeEvent } from "react"; //add useState later
 import { GameCardData } from "../../types/GameCardData";
 import { RowColour } from "../../types/enums";
 
@@ -19,17 +19,20 @@ const GameCard: React.FC<IGameCard> = ({ member, isOpponent, gameCardData, cellC
   //That can be used along with row colour + number to send to server
   // const [penalties, setPenalties] = useState<string[]>([]);
 
-  const handlePenaltyChange = (event: ChangeEvent<HTMLInputElement>) => {
+  //const handlePenaltyChange = (event: ChangeEvent<HTMLInputElement>) => {
     //const value = event.target.value;
     // setPenalties((prevPenalties) => [...prevPenalties, value]);
-    event.target.disabled = true;
-  };
+    //event.target.disabled = true;
+  //};
 
   const renderPenaltyCheckbox = (number: number) => {
+
+    const isPenaltyChecked = gameCardData.penalties.includes(number);
+
     return isOpponent ? (
       <li>
         <span
-          className={`penalty-checkbox ${gameCardData.penalties ? "checked" : ""}`}
+          className={`penalty-checkbox ${isPenaltyChecked ? "checked" : ""}`}
           aria-label="fake-checkbox"
         ></span>
         <label htmlFor="">{number}</label>
@@ -40,7 +43,8 @@ const GameCard: React.FC<IGameCard> = ({ member, isOpponent, gameCardData, cellC
           type="checkbox"
           id={`penalty${number}`}
           value={`Penalty_${number}`}
-          onChange={handlePenaltyChange}
+          checked={isPenaltyChecked}
+          disabled
           aria-label="penalty-checkbox"
         />
         <label htmlFor="">{number}</label>

--- a/client/src/components/GameCard/GameCard.tsx
+++ b/client/src/components/GameCard/GameCard.tsx
@@ -20,14 +20,14 @@ const GameCard: React.FC<IGameCard> = ({ member, isOpponent, gameCardData, cellC
   // const [penalties, setPenalties] = useState<string[]>([]);
 
   //const handlePenaltyChange = (event: ChangeEvent<HTMLInputElement>) => {
-    //const value = event.target.value;
-    // setPenalties((prevPenalties) => [...prevPenalties, value]);
-    //event.target.disabled = true;
+  //const value = event.target.value;
+  // setPenalties((prevPenalties) => [...prevPenalties, value]);
+  //event.target.disabled = true;
   //};
 
   const renderPenaltyCheckbox = (number: number) => {
-
-    const isPenaltyChecked = gameCardData.penalties.includes(number);
+    console.log(gameCardData)
+    const isPenaltyChecked = gameCardData.penalties?.includes(number);
 
     return isOpponent ? (
       <li>

--- a/client/src/pages/GamePage/GamePage.tsx
+++ b/client/src/pages/GamePage/GamePage.tsx
@@ -37,6 +37,7 @@ export const Game: React.FC<IGameProps> = ({
     row: string;
     num: number;
   } | null>(null);
+
   const handleCellClick = (rowColour: string, num: number) => {
     setPlayerChoice({ row: rowColour, num });
   };
@@ -76,6 +77,8 @@ export const Game: React.FC<IGameProps> = ({
   const hasSubmitted = gameState.players[userId].hasSubmittedChoice;
   const hasAvailableMoves = availableMoves;
   const hasRolled = gameState.hasRolled;
+  const activePlayer = gameState.activePlayer;
+
   console.log("player has moves:", hasAvailableMoves);
 
 
@@ -117,7 +120,7 @@ export const Game: React.FC<IGameProps> = ({
             gameCardData={gameState.players[userId].gameCard}
             cellClick={handleCellClick}
           />
-          {!hasAvailableMoves && !hasSubmitted && hasRolled ? (
+          {!hasAvailableMoves && !hasSubmitted && hasRolled && activePlayer ? (
             <button className="penalty-btn" onClick={handlePenalty}>Accept Penalty</button>
           ) :
             (<button onClick={handleNumberSelection} disabled={hasSubmitted}>Confirm</button>)

--- a/client/src/pages/GamePage/GamePage.tsx
+++ b/client/src/pages/GamePage/GamePage.tsx
@@ -21,7 +21,7 @@ interface IGameProps {
   userId: string;
   members: string[];
   gameState: QwixxLogic;
-  availableMoves: MoveAvailability;
+  availableMoves: boolean;
   // setGameBoardState: Dispatch<SetStateAction<GameBoard | null>>;
 }
 
@@ -65,16 +65,16 @@ export const Game: React.FC<IGameProps> = ({
   const filteredMembers = members.filter((member) => member !== userId);
 
   const handleNumberSelection = () => {
-    socket.emit("mark_numbers", {lobbyId, userId, playerChoice});
+    socket.emit("mark_numbers", { lobbyId, userId, playerChoice });
     console.log("player's choice:", playerChoice);
   }
 
   const handlePenalty = () => {
-    socket.emit("submit_penalty", {userId, lobbyId});
+    socket.emit("submit_penalty", { userId, lobbyId });
   }
 
   const hasSubmitted = gameState.players[userId].hasSubmittedChoice;
-  const hasAvailableMoves = availableMoves[userId];
+  const hasAvailableMoves = availableMoves;
   const hasRolled = gameState.hasRolled;
   console.log("player has moves:", hasAvailableMoves);
 
@@ -89,7 +89,7 @@ export const Game: React.FC<IGameProps> = ({
           socket={socket}
           lobbyId={lobbyId}
           gameState={gameState}
-          userId= {userId}
+          userId={userId}
         />
       </div>
       <div className="game-card-container">
@@ -104,7 +104,7 @@ export const Game: React.FC<IGameProps> = ({
               key={index}
               member={member}
               isOpponent={true}
-              gameCardData={gameState.players[member].gamecard}
+              gameCardData={gameState.players[member].gameCard}
               cellClick={handleCellClick}
             />
           ))}
@@ -114,15 +114,15 @@ export const Game: React.FC<IGameProps> = ({
           <GameCard
             member={userId}
             isOpponent={false}
-            gameCardData={gameState.players[userId].gamecard}
+            gameCardData={gameState.players[userId].gameCard}
             cellClick={handleCellClick}
           />
           {!hasAvailableMoves && !hasSubmitted && hasRolled ? (
             <button className="penalty-btn" onClick={handlePenalty}>Accept Penalty</button>
-          ):
-          (<button onClick={handleNumberSelection} disabled={hasSubmitted}>Confirm</button>)
+          ) :
+            (<button onClick={handleNumberSelection} disabled={hasSubmitted}>Confirm</button>)
           }
-          
+
         </div>
       </div>
     </div>

--- a/client/src/pages/GamePage/GamePage.tsx
+++ b/client/src/pages/GamePage/GamePage.tsx
@@ -8,6 +8,7 @@ import { QwixxLogic } from "../../types/qwixxLogic";
 // import { SetStateAction, Dispatch } from "react";
 // import { rowColour} from "../../../../shared/types";
 import DiceContainer from "../../components/Dice/DiceContainer";
+import { MoveAvailability } from "../../types/GameCardData";
 //interface GameState {
 //players: {
 //[playerId: string]: GameCardData
@@ -20,6 +21,7 @@ interface IGameProps {
   userId: string;
   members: string[];
   gameState: QwixxLogic;
+  availableMoves: MoveAvailability;
   // setGameBoardState: Dispatch<SetStateAction<GameBoard | null>>;
 }
 
@@ -29,6 +31,7 @@ export const Game: React.FC<IGameProps> = ({
   members,
   gameState,
   socket,
+  availableMoves,
 }) => {
   const [playerChoice, setPlayerChoice] = useState<{
     row: string;
@@ -66,6 +69,11 @@ export const Game: React.FC<IGameProps> = ({
     console.log("player's choice:", playerChoice);
   }
 
+  const hasSubmitted = gameState.players[userId].hasSubmittedChoice;
+  const hasAvailableMoves = availableMoves[userId];
+  console.log("player has moves:", hasAvailableMoves);
+
+
   return (
     <div className="game-page-container">
       {/* Left hand dice zone */}
@@ -91,7 +99,7 @@ export const Game: React.FC<IGameProps> = ({
               key={index}
               member={member}
               isOpponent={true}
-              gameCardData={gameState.players[member]}
+              gameCardData={gameState.players[member].gamecard}
               cellClick={handleCellClick}
             />
           ))}
@@ -101,10 +109,15 @@ export const Game: React.FC<IGameProps> = ({
           <GameCard
             member={userId}
             isOpponent={false}
-            gameCardData={gameState.players[userId]}
+            gameCardData={gameState.players[userId].gamecard}
             cellClick={handleCellClick}
           />
-          <button onClick={handleNumberSelection}>Confirm</button>
+          {!hasAvailableMoves && !hasSubmitted ? (
+            <button className="penalty-btn">Accept Penalty</button>
+          ):
+          (<button onClick={handleNumberSelection} disabled={hasSubmitted}>Confirm</button>)
+          }
+          
         </div>
       </div>
     </div>

--- a/client/src/pages/GamePage/GamePage.tsx
+++ b/client/src/pages/GamePage/GamePage.tsx
@@ -71,6 +71,7 @@ export const Game: React.FC<IGameProps> = ({
 
   const hasSubmitted = gameState.players[userId].hasSubmittedChoice;
   const hasAvailableMoves = availableMoves[userId];
+  const hasRolled = gameState.hasRolled;
   console.log("player has moves:", hasAvailableMoves);
 
 
@@ -112,7 +113,7 @@ export const Game: React.FC<IGameProps> = ({
             gameCardData={gameState.players[userId].gamecard}
             cellClick={handleCellClick}
           />
-          {!hasAvailableMoves && !hasSubmitted ? (
+          {!hasAvailableMoves && !hasSubmitted && hasRolled ? (
             <button className="penalty-btn">Accept Penalty</button>
           ):
           (<button onClick={handleNumberSelection} disabled={hasSubmitted}>Confirm</button>)

--- a/client/src/pages/GamePage/GamePage.tsx
+++ b/client/src/pages/GamePage/GamePage.tsx
@@ -69,6 +69,10 @@ export const Game: React.FC<IGameProps> = ({
     console.log("player's choice:", playerChoice);
   }
 
+  const handlePenalty = () => {
+    socket.emit("submit_penalty", {userId, lobbyId});
+  }
+
   const hasSubmitted = gameState.players[userId].hasSubmittedChoice;
   const hasAvailableMoves = availableMoves[userId];
   const hasRolled = gameState.hasRolled;
@@ -114,7 +118,7 @@ export const Game: React.FC<IGameProps> = ({
             cellClick={handleCellClick}
           />
           {!hasAvailableMoves && !hasSubmitted && hasRolled ? (
-            <button className="penalty-btn">Accept Penalty</button>
+            <button className="penalty-btn" onClick={handlePenalty}>Accept Penalty</button>
           ):
           (<button onClick={handleNumberSelection} disabled={hasSubmitted}>Confirm</button>)
           }

--- a/client/src/types/GameCardData.ts
+++ b/client/src/types/GameCardData.ts
@@ -13,3 +13,7 @@ export interface GameCardData {
   };
   penalties: number;
 }
+
+export interface MoveAvailability {
+  [playerName: string]: boolean;
+}

--- a/client/src/types/GameCardData.ts
+++ b/client/src/types/GameCardData.ts
@@ -15,5 +15,5 @@ export interface GameCardData {
 }
 
 export interface MoveAvailability {
-  [playerName: string]: boolean;
+  string: boolean;
 }

--- a/client/src/types/GameCardData.ts
+++ b/client/src/types/GameCardData.ts
@@ -11,7 +11,7 @@ export interface GameCardData {
     green: boolean;
     blue: boolean;
   };
-  penalties: number;
+  penalties: number[];
 }
 
 export interface MoveAvailability {

--- a/client/src/types/qwixxLogic.ts
+++ b/client/src/types/qwixxLogic.ts
@@ -1,19 +1,22 @@
 export interface QwixxLogic {
   players: {
     [name: string]: {
-      rows: {
-        red: number[];
-        yellow: number[];
-        green: number[];
-        blue: number[];
+      gamecard: {
+        rows: {
+          red: number[];
+          yellow: number[];
+          green: number[];
+          blue: number[];
+        };
+        isLocked: {
+          red: boolean;
+          yellow: boolean;
+          green: boolean;
+          blue: boolean;
+        };
+        penalties: number;
       };
-      isLocked: {
-        red: boolean;
-        yellow: boolean;
-        green: boolean;
-        blue: boolean;
-      };
-      penalties: number;
+      hasSubmittedChoice: boolean;
     };
   };
   dice: {

--- a/client/src/types/qwixxLogic.ts
+++ b/client/src/types/qwixxLogic.ts
@@ -14,7 +14,7 @@ export interface QwixxLogic {
           green: boolean;
           blue: boolean;
         };
-        penalties: number;
+        penalties: number[];
       };
       hasSubmittedChoice: boolean;
     };

--- a/client/src/types/qwixxLogic.ts
+++ b/client/src/types/qwixxLogic.ts
@@ -28,4 +28,5 @@ export interface QwixxLogic {
     blue: number;
   };
   activePlayer: string;
+  hasRolled: boolean;
 }

--- a/client/src/types/qwixxLogic.ts
+++ b/client/src/types/qwixxLogic.ts
@@ -1,7 +1,7 @@
 export interface QwixxLogic {
   players: {
     [name: string]: {
-      gamecard: {
+      gameCard: {
         rows: {
           red: number[];
           yellow: number[];

--- a/client/tests/components/GameCard/GameCard.test.tsx
+++ b/client/tests/components/GameCard/GameCard.test.tsx
@@ -21,53 +21,63 @@ interface PlayerChoice {
   number: number;
 }
 
+const mockAvailableMoves = {testUser1: true, testUser2: true, testUser3: true}
 const membersArrayMock = ["testUser1", "testUser2", "testUser3"];
 const gameState = {
   players: {
     testUser1: {
-      rows: {
-        red: [],
-        yellow: [],
-        green: [],
-        blue: [],
+      gamecard: {
+        rows: {
+          red: [],
+          yellow: [],
+          green: [],
+          blue: [],
+        },
+        isLocked: {
+          red: false,
+          yellow: false,
+          green: false,
+          blue: false,
+        },
+        penalties: [],
       },
-      isLocked: {
-        red: false,
-        yellow: false,
-        green: false,
-        blue: false,
+      hasSubmittedChoice: false,
       },
-      penalties: 0,
-    },
     testUser2: {
-      rows: {
-        red: [],
-        yellow: [],
-        green: [],
-        blue: [],
+      gamecard: {
+        rows: {
+          red: [],
+          yellow: [],
+          green: [],
+          blue: [],
+        },
+        isLocked: {
+          red: false,
+          yellow: false,
+          green: false,
+          blue: false,
+        },
+        penalties: [],
       },
-      isLocked: {
-        red: false,
-        yellow: false,
-        green: false,
-        blue: false,
-      },
-      penalties: 0,
+      hasSubmittedChoice: false,
     },
     testUser3: {
-      rows: {
-        red: [],
-        yellow: [],
-        green: [],
-        blue: [],
+      gamecard: {
+        rows: {
+          red: [],
+          yellow: [],
+          green: [],
+          blue: [],
+        },
+        isLocked: {
+          red: false,
+          yellow: false,
+          green: false,
+          blue: false,
+        },
+        penalties: [],
       },
-      isLocked: {
-        red: false,
-        yellow: false,
-        green: false,
-        blue: false,
-      },
-      penalties: 0,
+      hasSubmittedChoice: false,
     },
   },
   dice:{
@@ -78,6 +88,8 @@ const gameState = {
     green: 5,
     blue: 6,
   },
+  activePlayer: "testUser1" ,
+  hasRolled: false
 };
 
 let lobbyIdMock: string = "1234";
@@ -103,53 +115,53 @@ vi.mock(
     );
     
 
-const emptyGameCardData: QwixxLogic['players'][string] = {
-  rows: {
-    red: [],
-    yellow: [],
-    green: [],
-    blue: [],
-  },
-  isLocked: {
-    red: false,
-    yellow: false,
-    green: false,
-    blue: false,
-  },
-  penalties: 0,
-};
+const emptyGameCardData: QwixxLogic['players'][string]['gamecard'] = {
+    rows: {
+      red: [],
+      yellow: [],
+      green: [],
+      blue: [],
+    },
+    isLocked: {
+      red: false,
+      yellow: false,
+      green: false,
+      blue: false,
+    },
+    penalties: [],
+  };
 
-const gameCardDataWithNumbers: QwixxLogic['players'][string] = {
-  rows: {
-    red: [2, 3, 4, 5],
-    yellow: [2],
-    green: [11],
-    blue: [11],
-  },
-  isLocked: {
-    red: false,
-    yellow: false,
-    green: false,
-    blue: false,
-  },
-  penalties: 0,
-};
+const gameCardDataWithNumbers: QwixxLogic['players'][string]['gamecard'] = {
+    rows: {
+      red: [2, 3, 4, 5],
+      yellow: [2],
+      green: [11],
+      blue: [11],
+    },
+    isLocked: {
+      red: false,
+      yellow: false,
+      green: false,
+      blue: false,
+    },
+    penalties: [],
+  };
 
-const gameCardWithLockedRow: QwixxLogic['players'][string] = {
-  rows: {
-    red: [2, 3, 4, 5, 12],
-    yellow: [],
-    green: [],
-    blue: [],
-  },
-  isLocked: {
-    red: true,
-    yellow: false,
-    green: false,
-    blue: false,
-  },
-  penalties: 0,
-};
+const gameCardWithLockedRow: QwixxLogic['players'][string]['gamecard'] = {
+    rows: {
+      red: [2, 3, 4, 5, 12],
+      yellow: [],
+      green: [],
+      blue: [],
+    },
+    isLocked: {
+      red: true,
+      yellow: false,
+      green: false,
+      blue: false,
+    },
+    penalties: [],
+  };
 
 const cssRowRed = "row-red";
 const cssRowYellow = "row-yellow";
@@ -412,6 +424,7 @@ describe("Game Card Test:", () => {
                 members={membersArrayMock}
                 lobbyId={lobbyIdMock}
                 gameState={gameState}
+                availableMoves={mockAvailableMoves}
               />
           </MemoryRouter>
       )

--- a/client/tests/pages/GamePage/GamePage.test.tsx
+++ b/client/tests/pages/GamePage/GamePage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, test, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 //import { userEvent } from "@testing-library/user-event";
 import React from "react";
@@ -10,11 +10,10 @@ import { socket } from "../../../src/services/socketServices";
 
 const lobbyIdMock = "1234";
 const membersArrayMock = ["testUser1", "testUser2", "testUser3"];
-const mockAvailableMoves = {testUser1: true, testUser2: true, testUser3: true}
 const gameState = {
   players: {
     testUser1: {
-      gamecard: {
+      gameCard: {
         rows: {
           red: [],
           yellow: [],
@@ -32,7 +31,7 @@ const gameState = {
       hasSubmittedChoice: false,
     },
     testUser2: {
-      gamecard: {
+      gameCard: {
         rows: {
           red: [],
           yellow: [],
@@ -50,7 +49,7 @@ const gameState = {
       hasSubmittedChoice: false,
     },
     testUser3: {
-      gamecard: {
+      gameCard: {
         rows: {
           red: [],
           yellow: [],
@@ -65,10 +64,10 @@ const gameState = {
         },
         penalties: [],
       },
-      hasSubmittedChoice: false, 
+      hasSubmittedChoice: false,
     },
   },
-  dice:{
+  dice: {
     white1: 1,
     white2: 2,
     red: 3,
@@ -77,7 +76,7 @@ const gameState = {
     blue: 6,
   },
   activePlayer: "testUser1",
-  hasRolled: false,
+  hasRolled: true,
 };
 
 describe("Game Page Unit Test:", () => {
@@ -89,7 +88,7 @@ describe("Game Page Unit Test:", () => {
         members={membersArrayMock}
         lobbyId={lobbyIdMock}
         gameState={gameState}
-        availableMoves={mockAvailableMoves}
+        availableMoves={true}
       />
     );
 
@@ -98,17 +97,52 @@ describe("Game Page Unit Test:", () => {
 
     const user1 = screen.getByText("testUser1");
     const user2 = screen.getByText("testUser2");
-    const user3 = screen.getByText("testUser3"); 
+    const user3 = screen.getByText("testUser3");
     expect(user1).toBeVisible();
     expect(user2).toBeVisible();
-    expect(user3).toBeVisible(); 
+    expect(user3).toBeVisible();
 
     const opponentZone = screen.getByLabelText("opponent-zone");
-    const opponentGameCards = opponentZone.querySelectorAll(".game-card");  
+    const opponentGameCards = opponentZone.querySelectorAll(".game-card");
     expect(opponentGameCards.length).toBe(2);
 
     const playerZone = screen.getByLabelText("player-zone")
-    const playerGameCard = playerZone.querySelectorAll(".game-card"); 
-    expect(playerGameCard.length).toBe(1); 
+    const playerGameCard = playerZone.querySelectorAll(".game-card");
+    expect(playerGameCard.length).toBe(1);
   });
+
+  test("confirm button should render if there is an available move", () => {
+    render(
+      <GamePage
+        socket={socket}
+        userId={"testUser1"}
+        members={membersArrayMock}
+        lobbyId={lobbyIdMock}
+        gameState={gameState}
+        availableMoves={true}
+      />
+    );
+
+    const confirmBtn = screen.getByText("Confirm");
+    expect(confirmBtn).toBeVisible()
+  })
+
+  test("Accept Penalty button should render if there are no available moves", () => {
+    render(
+      <GamePage
+        socket={socket}
+        userId={"testUser1"}
+        members={membersArrayMock}
+        lobbyId={lobbyIdMock}
+        gameState={gameState}
+        availableMoves={false}
+      />
+    );
+
+    const acceptPenaltyBtc = screen.getByText("Accept Penalty");
+    expect(acceptPenaltyBtc).toBeVisible()
+  })
+
+  test.todo("When hasSubmited choice is true, confirm button is disabled")
+  test.todo("When a player confirms their selected number, that number cell becomes disabled")
 });

--- a/client/tests/pages/GamePage/GamePage.test.tsx
+++ b/client/tests/pages/GamePage/GamePage.test.tsx
@@ -10,52 +10,62 @@ import { socket } from "../../../src/services/socketServices";
 
 const lobbyIdMock = "1234";
 const membersArrayMock = ["testUser1", "testUser2", "testUser3"];
+const mockAvailableMoves = {testUser1: true, testUser2: true, testUser3: true}
 const gameState = {
   players: {
     testUser1: {
-      rows: {
-        red: [],
-        yellow: [],
-        green: [],
-        blue: [],
+      gamecard: {
+        rows: {
+          red: [],
+          yellow: [],
+          green: [],
+          blue: [],
+        },
+        isLocked: {
+          red: false,
+          yellow: false,
+          green: false,
+          blue: false,
+        },
+        penalties: [],
       },
-      isLocked: {
-        red: false,
-        yellow: false,
-        green: false,
-        blue: false,
-      },
-      penalties: 0,
+      hasSubmittedChoice: false,
     },
     testUser2: {
-      rows: {
-        red: [],
-        yellow: [],
-        green: [],
-        blue: [],
+      gamecard: {
+        rows: {
+          red: [],
+          yellow: [],
+          green: [],
+          blue: [],
+        },
+        isLocked: {
+          red: false,
+          yellow: false,
+          green: false,
+          blue: false,
+        },
+        penalties: [],
       },
-      isLocked: {
-        red: false,
-        yellow: false,
-        green: false,
-        blue: false,
-      },
-      penalties: 0,
+      hasSubmittedChoice: false,
     },
     testUser3: {
-      rows: {
-        red: [],
-        yellow: [],
-        green: [],
-        blue: [],
+      gamecard: {
+        rows: {
+          red: [],
+          yellow: [],
+          green: [],
+          blue: [],
+        },
+        isLocked: {
+          red: false,
+          yellow: false,
+          green: false,
+          blue: false,
+        },
+        penalties: [],
       },
-      isLocked: {
-        red: false,
-        yellow: false,
-        green: false,
-        blue: false,
-      },
-      penalties: 0,
+      hasSubmittedChoice: false, 
     },
   },
   dice:{
@@ -66,6 +76,8 @@ const gameState = {
     green: 5,
     blue: 6,
   },
+  activePlayer: "testUser1",
+  hasRolled: false,
 };
 
 describe("Game Page Unit Test:", () => {
@@ -77,6 +89,7 @@ describe("Game Page Unit Test:", () => {
         members={membersArrayMock}
         lobbyId={lobbyIdMock}
         gameState={gameState}
+        availableMoves={mockAvailableMoves}
       />
     );
 

--- a/server/src/models/DiceClass.ts
+++ b/server/src/models/DiceClass.ts
@@ -26,23 +26,27 @@ export default class Dice {
     };
   }
 
-  rollAllDice(): Record<DiceColour, number> {
+  public rollAllDice(): Record<DiceColour, number> {
     let diceColours = Object.keys(this._dice) as DiceColour[];
     diceColours.forEach((colour) => {
       const dieColour = colour as DiceColour;
       if (this._dice[dieColour].active === false) {
-        this._diceValues[dieColour] = 0;
+        this.diceValues[dieColour] = 0;
       } else {
         // this._dice[dieColour].rollDie();
         // this._diceValues[dieColour] = this._dice[dieColour].value;
-        this._diceValues[dieColour] = this._dice[dieColour].rollDie();
+        this.diceValues[dieColour] = this._dice[dieColour].rollDie();
       }
     });
-    return this._diceValues;
+    return this.diceValues;
   }
 
   get diceValues(): Record<DiceColour, number> {
     return this._diceValues;
+  }
+
+  public get whiteDiceSum() {
+    return this.diceValues.white1 + this.diceValues.white2
   }
 
   // get validColouredNumbers(): number[] {
@@ -51,8 +55,8 @@ export default class Dice {
   //   return whiteValues.flatMap(white => colouredValues.filter(value => value > 0).map(value => value + white));
   // }
 
-  get validColouredNumbers() {
-    const { white1, white2, ...colouredValues } = this._diceValues;
+  public get validColouredNumbers() {
+    const { white1, white2, ...colouredValues } = this.diceValues;
     //const result: { [key in rowColour]?: number[] } = {};
     const result: Partial<Record<rowColour, number[]>> = {};
 

--- a/server/src/models/DiceClass.ts
+++ b/server/src/models/DiceClass.ts
@@ -1,5 +1,6 @@
 import SixSidedDie from "./SixSidedDieClass";
 import { DiceColour } from "../enums/DiceColours";
+import { rowColour } from "../enums/rowColours";
 
 export default class Dice {
   private _dice: Record<DiceColour, SixSidedDie>;
@@ -52,15 +53,16 @@ export default class Dice {
 
   get validColouredNumbers() {
     const { white1, white2, ...colouredValues } = this._diceValues;
-    const result: { [key in DiceColour]?: number[] } = {};
-    
+    //const result: { [key in rowColour]?: number[] } = {};
+    const result: Partial<Record<rowColour, number[]>> = {};
+
     for (const [colour, value] of Object.entries(colouredValues)) {
-      const colourKey = colour as DiceColour;
+      const colourKey = colour as rowColour;
       if (value > 0) {
         result[colourKey] = [value + white1, value + white2];
       }
     }
-    
+
     return result;
   }
 

--- a/server/src/models/DiceClass.ts
+++ b/server/src/models/DiceClass.ts
@@ -2,9 +2,12 @@ import SixSidedDie from "./SixSidedDieClass";
 import { DiceColour } from "../enums/DiceColours";
 import { rowColour } from "../enums/rowColours";
 
+type TDice = Record<DiceColour, SixSidedDie>
+export type TDiceValues = Record<DiceColour, number>
+
 export default class Dice {
-  private _dice: Record<DiceColour, SixSidedDie>;
-  private _diceValues: Record<DiceColour, number>;
+  private _dice: TDice;
+  private _diceValues: TDiceValues;
 
   constructor(die: typeof SixSidedDie) {
     this._dice = {
@@ -26,7 +29,7 @@ export default class Dice {
     };
   }
 
-  public rollAllDice(): Record<DiceColour, number> {
+  public rollAllDice(): TDiceValues {
     let diceColours = Object.keys(this._dice) as DiceColour[];
     diceColours.forEach((colour) => {
       const dieColour = colour as DiceColour;
@@ -41,7 +44,7 @@ export default class Dice {
     return this.diceValues;
   }
 
-  get diceValues(): Record<DiceColour, number> {
+  get diceValues(): TDiceValues {
     return this._diceValues;
   }
 
@@ -78,7 +81,7 @@ export default class Dice {
     }
   }
 
-  serialize() {
-    return this._diceValues;
+  serialize(): TDiceValues {
+    return this.diceValues;
   }
 }

--- a/server/src/models/LobbyClass.ts
+++ b/server/src/models/LobbyClass.ts
@@ -66,11 +66,6 @@ export default class Lobby {
     return this._gameLogic.serialize();
   }
 
-  //Can be a problem if we ever wanted to make another game but keep the lobby.
-  rollDice(): Record<DiceColour, number> | undefined {
-    return this._gameLogic?.rollDice();
-  }
-
   isFull(): boolean {
     return this._players.length >= 4;
   }

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -51,6 +51,35 @@ export default class Player {
     this._gameCard.addPenalty();
   }
 
+  //input: sum of white or sum of white and coloured
+  //Output: boolean;
+  public hasAvailableMoves(validColouredNumbers: any) {
+    const numbers = this.gameCard.getHighestLowestMarkedNumbers();
+    let flag = false;
+
+    for (const key in validColouredNumbers) {
+      if (key === "red" || key === "yellow") {
+        if (
+          validColouredNumbers[key][0] > numbers[key] ||
+          validColouredNumbers[key][1] > numbers[key]
+        ) {
+          flag = true;
+        }
+      }
+
+      if (key === "blue" || key === "green") {
+        if (
+          validColouredNumbers[key][0] < numbers[key] ||
+          validColouredNumbers[key][1] < numbers[key]
+        ) {
+          flag = true;
+        }
+      }
+    }
+
+    return flag;
+  }
+
   serialize() {
     return {
       gamecard: this._gameCard.serialize(),

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -1,5 +1,12 @@
 import qwixxBaseGameCard from "./QwixxBaseGameCard";
 import { rowColour } from "../enums/rowColours";
+import { SerializeGameCard } from "./QwixxBaseGameCard";
+
+export interface SerializePlayer {
+  gameCard: SerializeGameCard;
+  hasSubmittedChoice: boolean;
+}
+
 export default class Player {
   private _name;
   private _gameCard: qwixxBaseGameCard;
@@ -47,14 +54,14 @@ export default class Player {
     return true;
   }
 
-  //TODO can remove this and just call the method from game card class directly
+  // TODO: can remove this and just call the method from game card class directly
   public addPenalty() {
     this._gameCard.addPenalty();
   }
 
-  serialize() {
+  serialize(): SerializePlayer {
     return {
-      gamecard: this._gameCard.serialize(),
+      gameCard: this._gameCard.serialize(),
       hasSubmittedChoice: this._hasSubmittedChoice,
     };
   }

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -17,6 +17,10 @@ export default class Player {
     return this._name;
   }
 
+  get gameCard(): qwixxBaseGameCard {
+    return this._gameCard;
+  }
+
   public get hasSubmittedChoice(): boolean {
     return this._hasSubmittedChoice;
   }

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -51,35 +51,6 @@ export default class Player {
     this._gameCard.addPenalty();
   }
 
-  //input: sum of white or sum of white and coloured
-  //Output: boolean;
-  public hasAvailableMoves(validColouredNumbers: any) {
-    const numbers = this.gameCard.getHighestLowestMarkedNumbers();
-    let flag = false;
-
-    for (const key in validColouredNumbers) {
-      if (key === "red" || key === "yellow") {
-        if (
-          validColouredNumbers[key][0] > numbers[key] ||
-          validColouredNumbers[key][1] > numbers[key]
-        ) {
-          flag = true;
-        }
-      }
-
-      if (key === "blue" || key === "green") {
-        if (
-          validColouredNumbers[key][0] < numbers[key] ||
-          validColouredNumbers[key][1] < numbers[key]
-        ) {
-          flag = true;
-        }
-      }
-    }
-
-    return flag;
-  }
-
   serialize() {
     return {
       gamecard: this._gameCard.serialize(),

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -47,6 +47,7 @@ export default class Player {
     return true;
   }
 
+  //TODO can remove this and just call the method from game card class directly
   public addPenalty() {
     this._gameCard.addPenalty();
   }

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -4,13 +4,13 @@ export default class Player {
   private _name;
   private _gameCard: qwixxBaseGameCard;
   private _hasSubmittedChoice;
-  private _submissionCount; 
+  private _submissionCount;
 
   constructor(name: string, gameCard: qwixxBaseGameCard) {
     this._name = name;
     this._gameCard = gameCard;
     this._hasSubmittedChoice = false;
-    this._submissionCount = 0; 
+    this._submissionCount = 0;
   }
 
   get name(): string {
@@ -35,15 +35,18 @@ export default class Player {
   }
 
   public markNumber(colour: rowColour, num: number) {
-   if(!this._gameCard.markNumbers(colour, num)){
-      return false
+    if (!this._gameCard.markNumbers(colour, num)) {
+      return false;
     }
 
-    this._submissionCount ++
+    this._submissionCount++;
     return true;
   }
 
   serialize() {
-    return this._gameCard.serialize();
+    return {
+      gamecard: this._gameCard.serialize(),
+      hasSubmittedChoice: this._hasSubmittedChoice,
+    };
   }
 }

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -2,6 +2,17 @@ import qwixxBaseGameCard from "./QwixxBaseGameCard";
 import { rowColour } from "../enums/rowColours";
 import { SerializeGameCard } from "./QwixxBaseGameCard";
 
+interface MarkNumberSuccess {
+  success: true;
+}
+
+interface MarkNumberFailure {
+  success: false;
+  errorMessage: string
+}
+
+type MarkNumberResult = MarkNumberSuccess | MarkNumberFailure
+
 export interface SerializePlayer {
   gameCard: SerializeGameCard;
   hasSubmittedChoice: boolean;
@@ -45,13 +56,15 @@ export default class Player {
     return this._submissionCount;
   }
 
-  public markNumber(colour: rowColour, num: number) {
-    if (!this._gameCard.markNumbers(colour, num)) {
-      return false;
+  public markNumber(colour: rowColour, num: number): MarkNumberResult {
+    const res = this.gameCard.markNumbers(colour, num);
+
+    if (!res.success) {
+      return { success: res.success, errorMessage: res.errorMessage }
     }
 
     this._submissionCount++;
-    return true;
+    return { success: true };
   }
 
   // TODO: can remove this and just call the method from game card class directly

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -67,11 +67,6 @@ export default class Player {
     return { success: true };
   }
 
-  // TODO: can remove this and just call the method from game card class directly
-  public addPenalty() {
-    this._gameCard.addPenalty();
-  }
-
   serialize(): SerializePlayer {
     return {
       gameCard: this._gameCard.serialize(),

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -47,6 +47,10 @@ export default class Player {
     return true;
   }
 
+  public addPenalty() {
+    this._gameCard.addPenalty();
+  }
+
   serialize() {
     return {
       gamecard: this._gameCard.serialize(),

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -1,5 +1,16 @@
 import { rowColour } from "../enums/rowColours";
 
+interface MarkNumbersSuccess {
+  success: true;
+}
+
+interface MarkNumbersFailre {
+  success: false;
+  errorMessage: string;
+}
+
+type MarkNumbersResult = MarkNumbersSuccess | MarkNumbersFailre
+
 type RowValues = Record<rowColour, number[]>
 type RowLocks = Record<rowColour, boolean>
 
@@ -55,13 +66,20 @@ export default class qwixxBaseGameCard {
     this._rows[row].push(number)
   }
 
-  public markNumbers(row: rowColour, number: number) {
-    if (!this.isValidMove(row, number) || this._rows[row].includes(number)) {
-      return false
+  public markNumbers(row: rowColour, number: number): MarkNumbersResult {
+    if (this._rows[row].includes(number)) {
+      return { success: false, errorMessage: `Number ${number} is already marked in ${row} row.` }
+    }
+
+    if (!this.isValidMove(row, number)) {
+      return {
+        success: false, errorMessage:
+          "Invalid move. Number is not higher/lower than previous marked number"
+      }
     }
 
     this.addNumberToRow(row, number)
-    return true
+    return { success: true }
 
     //    this._rows[row].push(number)
 
@@ -85,18 +103,20 @@ export default class qwixxBaseGameCard {
     this._penalties.push(this._penalties.length + 1);
   }
 
-  //TODO maybe change to private
+  //TODO: maybe change to private
   public getHighestMarkedNumber(row: rowColour): number {
     const markedNumbers = this._rows[row];
     return markedNumbers.length ? Math.max(...markedNumbers) : 1;
   }
 
-  //TOOD maybe change to private
+  //TODO: maybe change to private
   public getLowestMarkedNumber(row: rowColour): number {
     const markedNumbers = this._rows[row];
     return markedNumbers.length ? Math.min(...markedNumbers) : 13;
   }
 
+  // TODO: Better error handling for when colour is invalid.
+  // It should already be validated in QwixxLogic but it is also being handled here.
   private isValidMove(colour: rowColour, num: number): boolean {
     if (colour === rowColour.Red || colour === rowColour.Yellow) {
       return this.getHighestMarkedNumber(colour) < num;

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -42,13 +42,26 @@ export default class qwixxBaseGameCard {
     return this._numbers;
   }
 
+  private addNumberToRow(row: rowColour, number: number) {
+    this._rows[row].push(number)
+  }
+
   public markNumbers(row: rowColour, number: number) {
-    if (!this._rows[row].includes(number)) {
-      this._rows[row].push(number);
-      return true;
-    } else {
-      return false;
+    if (!this.isValidMove(row, number) || this._rows[row].includes(number)) {
+      return false
     }
+
+    this.addNumberToRow(row, number)
+    return true
+
+    //    this._rows[row].push(number)
+
+    //    if (!this._rows[row].includes(number)) {
+    //      this._rows[row].push(number);
+    //      return true;
+    //    } else {
+    //      return false;
+    //    }
   }
 
   get isLocked() {
@@ -63,11 +76,13 @@ export default class qwixxBaseGameCard {
     this._penalties.push(this._penalties.length + 1);
   }
 
+  //TODO maybe change to private
   public getHighestMarkedNumber(row: rowColour): number {
     const markedNumbers = this._rows[row];
     return markedNumbers.length ? Math.max(...markedNumbers) : 1;
   }
 
+  //TOOD maybe change to private
   public getLowestMarkedNumber(row: rowColour): number {
     const markedNumbers = this._rows[row];
     return markedNumbers.length ? Math.min(...markedNumbers) : 13;

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -72,4 +72,18 @@ export default class qwixxBaseGameCard {
     const markedNumbers = this._rows[row];
     return markedNumbers.length ? Math.min(...markedNumbers) : 13;
   }
+
+  public getHighestLowestMarkedNumbers() {
+    const redNumber = this.getHighestMarkedNumber(rowColour.Red);
+    const yellowNumber = this.getHighestMarkedNumber(rowColour.Yellow);
+    const blueNumber = this.getLowestMarkedNumber(rowColour.Blue);
+    const greenNumber = this.getLowestMarkedNumber(rowColour.Green);
+
+    return {
+      [rowColour.Red]: redNumber,
+      [rowColour.Yellow]: yellowNumber,
+      [rowColour.Blue]: blueNumber,
+      [rowColour.Green]: greenNumber,
+    };
+  }
 }

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -128,6 +128,7 @@ export default class qwixxBaseGameCard {
     return false;
   }
 
+  // TODO: Doesn't check valid moves for white1 + white2
   public hasAvailableMoves(
     diceValues: Partial<Record<rowColour, number[]>>
   ): boolean {

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -3,7 +3,7 @@ import { rowColour } from "../enums/rowColours";
 type RowValues = Record<rowColour, number[]>
 type RowLocks = Record<rowColour, boolean>
 
-interface SerializeGameCard {
+export interface SerializeGameCard {
   rows: RowValues;
   isLocked: RowLocks;
   penalties: number[];

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -59,6 +59,10 @@ export default class qwixxBaseGameCard {
     return this._penalties;
   }
 
+  public addPenalty() {
+    this._penalties.push(1);
+  }
+
   public getHighestMarkedNumber(row: rowColour): number {
     const markedNumbers = this._rows[row];
     return markedNumbers.length ? Math.max(...markedNumbers) : 1;

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -60,7 +60,7 @@ export default class qwixxBaseGameCard {
   }
 
   public addPenalty() {
-    this._penalties.push(1);
+    this._penalties.push(this._penalties.length + 1);
   }
 
   public getHighestMarkedNumber(row: rowColour): number {

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -30,7 +30,7 @@ export default class qwixxBaseGameCard {
     return {
       rows: this._rows,
       isLocked: this._isLocked,
-      penalties: this._penalties.length,
+      penalties: this._penalties,
     };
   }
 

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -1,9 +1,18 @@
 import { rowColour } from "../enums/rowColours";
 
+type RowValues = Record<rowColour, number[]>
+type RowLocks = Record<rowColour, boolean>
+
+interface SerializeGameCard {
+  rows: RowValues;
+  isLocked: RowLocks;
+  penalties: number[];
+}
+
 export default class qwixxBaseGameCard {
-  private _rows: { [key in rowColour]: number[] };
+  private _rows: RowValues;
   private _numbers: number[];
-  private _isLocked: { [key in rowColour]: boolean };
+  private _isLocked: RowLocks;
   private _penalties: number[];
 
   constructor() {
@@ -26,7 +35,7 @@ export default class qwixxBaseGameCard {
     this._penalties = [];
   }
 
-  serialize() {
+  public serialize(): SerializeGameCard {
     return {
       rows: this._rows,
       isLocked: this._isLocked,

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -84,13 +84,17 @@ export default class qwixxBaseGameCard {
     return false;
   }
 
-  public hasAvailableMoves(diceValues: Record<rowColour, number[]>): boolean {
+  public hasAvailableMoves(
+    diceValues: Partial<Record<rowColour, number[]>>
+  ): boolean {
     for (const row in diceValues) {
       const colour = row as rowColour;
-      const [num1, num2] = diceValues[colour];
+      const [num1, num2] = diceValues[colour] ?? [];
 
-      if (this.isValidMove(colour, num1) || this.isValidMove(colour, num2)) {
-        return true;
+      if (num1 !== undefined && num2 !== undefined) {
+        if (this.isValidMove(colour, num1) || this.isValidMove(colour, num2)) {
+          return true;
+        }
       }
     }
     return false;

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -58,4 +58,14 @@ export default class qwixxBaseGameCard {
   get penalties() {
     return this._penalties;
   }
+
+  public getHighestMarkedNumber(row: rowColour): number {
+    const markedNumbers = this._rows[row];
+    return markedNumbers.length ? Math.max(...markedNumbers) : 1;
+  }
+
+  public getLowestMarkedNumber(row: rowColour): number {
+    const markedNumbers = this._rows[row];
+    return markedNumbers.length ? Math.min(...markedNumbers) : 13;
+  }
 }

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -73,17 +73,26 @@ export default class qwixxBaseGameCard {
     return markedNumbers.length ? Math.min(...markedNumbers) : 13;
   }
 
-  public getHighestLowestMarkedNumbers() {
-    const redNumber = this.getHighestMarkedNumber(rowColour.Red);
-    const yellowNumber = this.getHighestMarkedNumber(rowColour.Yellow);
-    const blueNumber = this.getLowestMarkedNumber(rowColour.Blue);
-    const greenNumber = this.getLowestMarkedNumber(rowColour.Green);
+  private isValidMove(colour: rowColour, num: number): boolean {
+    if (colour === rowColour.Red || colour === rowColour.Yellow) {
+      return this.getHighestMarkedNumber(colour) < num;
+    }
 
-    return {
-      [rowColour.Red]: redNumber,
-      [rowColour.Yellow]: yellowNumber,
-      [rowColour.Blue]: blueNumber,
-      [rowColour.Green]: greenNumber,
-    };
+    if (colour === rowColour.Blue || colour === rowColour.Green) {
+      return this.getLowestMarkedNumber(colour) > num;
+    }
+    return false;
+  }
+
+  public hasAvailableMoves(diceValues: Record<rowColour, number[]>): boolean {
+    for (const row in diceValues) {
+      const colour = row as rowColour;
+      const [num1, num2] = diceValues[colour];
+
+      if (this.isValidMove(colour, num1) || this.isValidMove(colour, num2)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -189,6 +189,27 @@ export default class QwixxLogic {
     };
   }
 
+  public validMoveAvailable(): Record<string, boolean> {
+    const playerMoveAvailable: Record<string, boolean> = {};
+
+    for (const player of this._playersArray) {
+      let hasValidMove = false;
+
+      for (let row of ["red", "yellow", "green", "blue"]) {
+        for (let num = 2; num <= 12; num++) {
+          const validationResult = this.validMove(player.name, row, num);
+          if (validationResult.isValid) {
+            hasValidMove = true;
+            break;
+          }
+        }
+        if (hasValidMove) break;
+      }
+      playerMoveAvailable[player.name] = hasValidMove;
+    }
+    return playerMoveAvailable;
+  }
+
   public endTurn(playerName: string) {
     const player = this._playersArray.find(
       (player) => player.name === playerName

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -1,7 +1,6 @@
 import Player from "../models/PlayerClass";
 import Dice from "../models/DiceClass";
 import { rowColour } from "../enums/rowColours";
-import { DiceColour } from "../enums/DiceColours";
 import { SerializePlayer } from "../models/PlayerClass";
 import { TDiceValues } from "../models/DiceClass";
 
@@ -131,10 +130,9 @@ export default class QwixxLogic {
     const markNumberResult = player.markNumber(colourToMark, num);
 
     // returning an object literal because it is a game-rule violation
-    if (!markNumberResult) {
+    if (!markNumberResult.success) {
       //throw new Error("Invalid move: cannot mark this number.");
-      //TODO: Update return of markNumber
-      return { success: false, error: markNumberResult.errorMessage }
+      return { success: markNumberResult.success, error: markNumberResult.errorMessage }
     }
 
     if (

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -7,6 +7,12 @@ interface ValidationResult {
   isValid: boolean;
   errorMessage: Error | null;
 }
+
+interface rollDiceResults {
+  hasRolled: boolean;
+  hasAvailableMoves: boolean;
+  diceValues: Record<DiceColour, number>;
+}
 export default class QwixxLogic {
   private _playersArray: Player[];
   private _dice: Dice;
@@ -20,16 +26,18 @@ export default class QwixxLogic {
     this._hasRolled = false;
   }
 
-  public rollDice(): Record<DiceColour, number> {
+  public rollDice(): rollDiceResults {
     this._hasRolled = true;
     const hasRolled = this.hasRolled;
     const validColouredNumbers = this._dice.validColouredNumbers;
-    const hasAvailableMoves = this.activePlayer.hasAvailableMoves(validColouredNumbers);
+    const hasAvailableMoves =
+      this.activePlayer.gameCard.hasAvailableMoves(validColouredNumbers);
 
     return {
       hasRolled,
       hasAvailableMoves,
-      diceValues: this._dice.rollAllDice()
+      diceValues: this._dice.rollAllDice(),
+    };
   }
 
   private get activePlayer() {
@@ -223,15 +231,15 @@ export default class QwixxLogic {
   }
 
   //public validMoveAvailable(): Record<string, boolean> {
-    //const playerMoveAvailable: Record<string, boolean> = {};
+  //const playerMoveAvailable: Record<string, boolean> = {};
 
-    //for (const player of this._playersArray) {
-      //let hasValidMove = false;
+  //for (const player of this._playersArray) {
+  //let hasValidMove = false;
 
-      //for (let row of ["red", "yellow", "green", "blue"]) {
-       // for (let num = 2; num <= 12; num++) {
-         // const validationResult = this.validMove(player.name, row, num);
-          //if (validationResult.isValid) {
+  //for (let row of ["red", "yellow", "green", "blue"]) {
+  // for (let num = 2; num <= 12; num++) {
+  // const validationResult = this.validMove(player.name, row, num);
+  //if (validationResult.isValid) {
   //           hasValidMove = true;
   //           break;
   //         }

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -86,6 +86,7 @@ export default class QwixxLogic {
       if (!markSuccess) {
         throw new Error("Invalid move: cannot mark this number.");
       }
+      player.markSubmitted();
       this.processPlayersSubmission();
     }
 

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -29,7 +29,7 @@ export default class QwixxLogic {
     return this._playersArray[this._currentTurnIndex];
   }
 
-  private get hasRolled() {
+  public get hasRolled() {
     return this._hasRolled;
   }
 
@@ -134,6 +134,11 @@ export default class QwixxLogic {
       };
     }
 
+    const highestMarkedNumber =
+      player.gameCard.getHighestMarkedNumber(colourToMark);
+    const lowestMarkedNumber =
+      player.gameCard.getLowestMarkedNumber(colourToMark);
+
     /*
      * Checks the non-active player's number selection.
      */
@@ -181,6 +186,27 @@ export default class QwixxLogic {
           "Number selected doesn't equal to sum of white die and coloured die."
         ),
       };
+    }
+
+    /*add check for number being lower or higher than last checked number */
+    if (colourToMark === "red" || colourToMark === "yellow") {
+      if (num <= highestMarkedNumber) {
+        return {
+          isValid: false,
+          errorMessage: new Error(
+            "Number must be above the last marked number"
+          ),
+        };
+      }
+    } else if (colourToMark === "green" || colourToMark === "blue") {
+      if (num >= lowestMarkedNumber) {
+        return {
+          isValid: false,
+          errorMessage: new Error(
+            "Number must be below the last marked number"
+          ),
+        };
+      }
     }
 
     return {
@@ -250,6 +276,7 @@ export default class QwixxLogic {
       players: serializedPlayers,
       dice: this._dice.serialize(),
       activePlayer: this.activePlayer.name,
+      hasRolled: this._hasRolled,
     };
   }
 }

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -173,13 +173,6 @@ export default class QwixxLogic {
       };
     }
 
-    // TODO: Should this check be done in the game card class?
-    //
-    //    const highestMarkedNumber =
-    //      player.gameCard.getHighestMarkedNumber(colourToMark);
-    //    const lowestMarkedNumber =
-    //      player.gameCard.getLowestMarkedNumber(colourToMark);
-
     /*
      * Checks the non-active player's number selection.
      */
@@ -223,29 +216,6 @@ export default class QwixxLogic {
       };
     }
 
-    // TODO: - This should be done in the Game Card class
-    //
-    /*add check for number being lower or higher than last checked number */
-    //    if (colourToMark === "red" || colourToMark === "yellow") {
-    //      if (num <= highestMarkedNumber) {
-    //        return {
-    //          isValid: false,
-    //          errorMessage: new Error(
-    //            "Number must be above the last marked number"
-    //          ),
-    //        };
-    //      }
-    //    } else if (colourToMark === "green" || colourToMark === "blue") {
-    //      if (num >= lowestMarkedNumber) {
-    //        return {
-    //          isValid: false,
-    //          errorMessage: new Error(
-    //            "Number must be below the last marked number"
-    //          ),
-    //        };
-    //      }
-    //    }
-
     return {
       isValid: true,
     };
@@ -281,8 +251,7 @@ export default class QwixxLogic {
       throw new Error("Player not found");
     }
 
-    //TODO: call the method directly from game card class instead of through player class
-    player.addPenalty();
+    player.gameCard.addPenalty()
     player.markSubmitted();
 
     this.processPlayersSubmission();

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -22,7 +22,14 @@ export default class QwixxLogic {
 
   public rollDice(): Record<DiceColour, number> {
     this._hasRolled = true;
-    return this._dice.rollAllDice();
+    const hasRolled = this.hasRolled;
+    const validColouredNumbers = this._dice.validColouredNumbers;
+    const hasAvailableMoves = this.activePlayer.hasAvailableMoves(validColouredNumbers);
+
+    return {
+      hasRolled,
+      hasAvailableMoves,
+      diceValues: this._dice.rollAllDice()
   }
 
   private get activePlayer() {
@@ -215,26 +222,26 @@ export default class QwixxLogic {
     };
   }
 
-  public validMoveAvailable(): Record<string, boolean> {
-    const playerMoveAvailable: Record<string, boolean> = {};
+  //public validMoveAvailable(): Record<string, boolean> {
+    //const playerMoveAvailable: Record<string, boolean> = {};
 
-    for (const player of this._playersArray) {
-      let hasValidMove = false;
+    //for (const player of this._playersArray) {
+      //let hasValidMove = false;
 
-      for (let row of ["red", "yellow", "green", "blue"]) {
-        for (let num = 2; num <= 12; num++) {
-          const validationResult = this.validMove(player.name, row, num);
-          if (validationResult.isValid) {
-            hasValidMove = true;
-            break;
-          }
-        }
-        if (hasValidMove) break;
-      }
-      playerMoveAvailable[player.name] = hasValidMove;
-    }
-    return playerMoveAvailable;
-  }
+      //for (let row of ["red", "yellow", "green", "blue"]) {
+       // for (let num = 2; num <= 12; num++) {
+         // const validationResult = this.validMove(player.name, row, num);
+          //if (validationResult.isValid) {
+  //           hasValidMove = true;
+  //           break;
+  //         }
+  //       }
+  //       if (hasValidMove) break;
+  //     }
+  //     playerMoveAvailable[player.name] = hasValidMove;
+  //   }
+  //   return playerMoveAvailable;
+  // }
 
   public endTurn(playerName: string) {
     const player = this.playerExistsInLobby(playerName);

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -81,9 +81,7 @@ export default class QwixxLogic {
       throw validationResult.errorMessage;
     }
 
-    const player = this._playersArray.find(
-      (player) => player.name === playerName
-    );
+    const player = this.playerExistsInLobby(playerName);
 
     if (player) {
       const markSuccess = player.markNumber(colourToMark, num);
@@ -123,9 +121,7 @@ export default class QwixxLogic {
       };
     }
 
-    const player = this._playersArray.find(
-      (player) => player.name === playerName
-    );
+    const player = this.playerExistsInLobby(playerName);
 
     if (!player) {
       return { isValid: false, errorMessage: new Error("Player not found.") };
@@ -241,9 +237,7 @@ export default class QwixxLogic {
   }
 
   public endTurn(playerName: string) {
-    const player = this._playersArray.find(
-      (player) => player.name === playerName
-    );
+    const player = this.playerExistsInLobby(playerName);
 
     if (!player) {
       throw new Error("Player not found.");
@@ -267,9 +261,7 @@ export default class QwixxLogic {
   }
 
   public processPenalty(playerName: string) {
-    const player = this._playersArray.find(
-      (player) => player.name === playerName
-    );
+    const player = this.playerExistsInLobby(playerName);
     if (!player) {
       throw new Error("Player not found");
     }

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -2,11 +2,13 @@ import Player from "../models/PlayerClass";
 import Dice from "../models/DiceClass";
 import { rowColour } from "../enums/rowColours";
 import { DiceColour } from "../enums/DiceColours";
+import { SerializePlayer } from "../models/PlayerClass";
+import { TDiceValues } from "../models/DiceClass";
 
 interface rollDiceResults {
   hasRolled: boolean;
   hasAvailableMoves: boolean;
-  diceValues: Record<DiceColour, number>;
+  diceValues: TDiceValues;
 }
 
 interface MoveValidationSuccess {
@@ -21,8 +23,8 @@ interface MoveValidationFailure {
 type ValidationResult = MoveValidationSuccess | MoveValidationFailure
 
 interface SerializedGameState {
-  players: { [playerName: string]: { gameCard: object; hasSubmittedChoice: boolean } };
-  dice: { [key: string]: number };
+  players: Record<string, SerializePlayer>;
+  dice: TDiceValues;
   activePlayer: string;
   hasRolled: boolean;
 }
@@ -117,8 +119,8 @@ export default class QwixxLogic {
       throw new Error("Player not found.")
     }
 
-    //Passed the player object to validMove instead of playerName
-    const validationResult = this.validMove(player, row, num);
+    //Passed the player object to validateMove instead of playerName
+    const validationResult = this.validateMove(player, row, num);
 
     // returning an object literal because it is a game-rule violation
     if (!validationResult.isValid) {
@@ -146,7 +148,7 @@ export default class QwixxLogic {
     return { success: true, data: this.serialize() };
   }
 
-  private validMove(
+  private validateMove(
     player: Player,
     row: string,
     num: number
@@ -248,7 +250,6 @@ export default class QwixxLogic {
 
     return {
       isValid: true,
-      errorMessage: null,
     };
   }
 
@@ -295,13 +296,11 @@ export default class QwixxLogic {
   //   return this._playersArray;
   // }
 
-  //Do we need a type of player.serialize? It contains the result of gameCard.serialize.
-  //then we would need to update the type of qwixxLogic.serialize
   public serialize(): SerializedGameState {
     const serializedPlayers = this._playersArray.reduce((acc, player) => {
       acc[player.name] = player.serialize();
       return acc;
-    }, {} as Record<string, any>);
+    }, {} as Record<string, SerializePlayer>);
 
     return {
       players: serializedPlayers,

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -86,8 +86,14 @@ export default class QwixxLogic {
       if (!markSuccess) {
         throw new Error("Invalid move: cannot mark this number.");
       }
-      player.markSubmitted();
-      this.processPlayersSubmission();
+
+      if (
+        (player === this.activePlayer && player.submissionCount === 2) ||
+        (player !== this.activePlayer && player.submissionCount === 1)
+      ) {
+        player.markSubmitted();
+        this.processPlayersSubmission();
+      }
     }
 
     return this.serialize();
@@ -177,16 +183,9 @@ export default class QwixxLogic {
       };
     }
 
-    if (
-      (player === this.activePlayer && player.submissionCount === 2) ||
-      (player !== this.activePlayer && player.submissionCount === 1)
-    ) {
-      return { isValid: true, errorMessage: null };
-    }
-
     return {
-      isValid: false,
-      errorMessage: new Error("Unknown error or invalid game state."),
+      isValid: true,
+      errorMessage: null,
     };
   }
 

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -29,6 +29,10 @@ export default class QwixxLogic {
     return this._playersArray[this._currentTurnIndex];
   }
 
+  public playerExistsInLobby(playerName: string): Player | undefined {
+    return this._playersArray.find((player) => player.name === playerName);
+  }
+
   public get hasRolled() {
     return this._hasRolled;
   }
@@ -256,6 +260,22 @@ export default class QwixxLogic {
     if (player === this.activePlayer) {
       player.markSubmitted();
     }
+
+    this.processPlayersSubmission();
+
+    return this.serialize();
+  }
+
+  public processPenalty(playerName: string) {
+    const player = this._playersArray.find(
+      (player) => player.name === playerName
+    );
+    if (!player) {
+      throw new Error("Player not found");
+    }
+
+    player.addPenalty();
+    player.markSubmitted();
 
     this.processPlayersSubmission();
 

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -29,7 +29,7 @@ export default class QwixxLogic {
     return this._playersArray[this._currentTurnIndex];
   }
 
-  public playerExistsInLobby(playerName: string): Player | undefined {
+  private playerExistsInLobby(playerName: string): Player | undefined {
     return this._playersArray.find((player) => player.name === playerName);
   }
 

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -246,13 +246,6 @@ export default function initializeSocketHandler(io: Server) {
         return;
       }
 
-      const playerExists = gameState.playerExistsInLobby(userId);
-
-      if (!playerExists) {
-        socket.emit("error_occured", { message: "Player not found" });
-        return;
-      }
-
       try {
         const updatedGameState = gameState?.processPenalty(userId);
         console.log("penalty processed gamedata:", updatedGameState);

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -229,12 +229,8 @@ export default function initializeSocketHandler(io: Server) {
 
     socket.on("roll_dice", ({ lobbyId }) => {
       const diceResult = lobbiesMap[lobbyId].gameLogic?.rollDice();
-
-      io.to(lobbyId).emit("dice_rolled", {
-        dice: diceResult?.diceValues,
-        moveAvailability: diceResult?.hasAvailableMoves,
-        hasRolled: diceResult?.hasRolled,
-      });
+      console.log(diceResult)
+      io.to(lobbyId).emit("dice_rolled", diceResult);
     });
 
     socket.on("submit_penalty", ({ userId, lobbyId }) => {

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -38,7 +38,7 @@ export default function initializeSocketHandler(io: Server) {
   const userIdList: { [key: string]: string } = {};
 
   io.on("connection", (socket) => {
-    console.log(`A user connected: ${socket.id}`);
+    //console.log(`A user connected: ${socket.id}`);
 
     socket.on("create_lobby", (userId, callback) => {
       const rooms = Array.from(io.sockets.adapter.rooms.keys());
@@ -53,9 +53,9 @@ export default function initializeSocketHandler(io: Server) {
       roomSockets[socket.id] = room;
       lobbiesMap[room].addPlayer(userId);
       callback(room);
-      console.log(
-        `Server: create_lobby_success: Client "${userId}" created ${room}`
-      );
+      //console.log(
+      //  `Server: create_lobby_success: Client "${userId}" created ${room}`
+      //);
     });
 
     socket.on("join_lobby", ({ localLobbyId, userId }, callback) => {
@@ -91,7 +91,7 @@ export default function initializeSocketHandler(io: Server) {
         const currentLobby = roomSockets[socket.id];
         socket.leave(currentLobby);
         io.to(currentLobby).emit("user_left", { userId: socket.id });
-        console.log("socket left room");
+        //console.log("socket left room");
       }
 
       //Join lobby
@@ -110,8 +110,8 @@ export default function initializeSocketHandler(io: Server) {
         error: "",
         lobbyMembers: lobbiesMap[localLobbyId].players,
       });
-      console.log(`Client "${userId}" joined: ${roomSockets[socket.id]}`);
-      console.log(lobbiesMap[localLobbyId].players);
+      //console.log(`Client "${userId}" joined: ${roomSockets[socket.id]}`);
+      //console.log(lobbiesMap[localLobbyId].players);
     });
 
     // When a player explicity leaves a room - checks if roomId is already in roomSockets object. Then it will leave the currentRoom and also remove from roomSockets object.
@@ -171,7 +171,7 @@ export default function initializeSocketHandler(io: Server) {
         };
 
         io.to(lobbyId).emit("game_initialised", responseData);
-        console.log("initialGameState:", initialGameState);
+        //console.log("initialGameState:", initialGameState);
       }
     });
 
@@ -196,7 +196,7 @@ export default function initializeSocketHandler(io: Server) {
         const { row: rowColour, num } = playerChoice;
         const res = gameLogic?.makeMove(userId, rowColour, num);
 
-        console.log("Updated game state:", res);
+        //console.log("Updated game state:", res);
 
         if (!res?.success) {
           const responseData = { message: res?.error }
@@ -213,6 +213,9 @@ export default function initializeSocketHandler(io: Server) {
           socket.emit("error_occured", { message: err.message });
         }
       }
+
+      // TODO: Delete commented out code
+
       //if (gameLogic?.haveAllPlayersSubmitted()) {
       //gameLogic.resetAllPlayersSubmission();
       //gameLogic.nextTurn();
@@ -252,7 +255,7 @@ export default function initializeSocketHandler(io: Server) {
 
       try {
         const updatedGameState = gameState?.processPenalty(userId);
-        console.log("penalty processed gamedata:", updatedGameState);
+        //console.log("penalty processed gamedata:", updatedGameState);
 
         io.to(lobbyId).emit("penalty_processed", {
           responseData: updatedGameState,

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -254,9 +254,11 @@ export default function initializeSocketHandler(io: Server) {
       }
 
       try {
-        gameState?.processPenalty(userId);
+        const updatedGameState = gameState?.processPenalty(userId);
+        console.log("penalty processed gamedata:", updatedGameState);
+
         io.to(lobbyId).emit("penalty_processed", {
-          updatedGameState: gameState.serialize(),
+          responseData: updatedGameState,
         });
       } catch (err) {
         if (err instanceof Error) {

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -218,7 +218,12 @@ export default function initializeSocketHandler(io: Server) {
 
     socket.on("roll_dice", ({ lobbyId }) => {
       const diceResult = lobbiesMap[lobbyId].rollDice();
-      io.to(lobbyId).emit("dice_rolled", { dice: diceResult });
+      const moveAvailability =
+        lobbiesMap[lobbyId].gameLogic?.validMoveAvailable();
+      io.to(lobbyId).emit("dice_rolled", {
+        dice: diceResult,
+        moveAvailability,
+      });
     });
   });
 }

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -219,14 +219,12 @@ export default function initializeSocketHandler(io: Server) {
     });
 
     socket.on("roll_dice", ({ lobbyId }) => {
-      const diceResult = lobbiesMap[lobbyId].rollDice();
-      const hasRolled = lobbiesMap[lobbyId].gameLogic?.hasRolled;
-      const moveAvailability =
-        lobbiesMap[lobbyId].gameLogic?.validMoveAvailable();
+      const diceResult = lobbiesMap[lobbyId].gameLogic?.rollDice();
+
       io.to(lobbyId).emit("dice_rolled", {
-        dice: diceResult,
-        moveAvailability,
-        hasRolled,
+        dice: diceResult?.diceValues,
+        moveAvailability: diceResult?.hasAvailableMoves,
+        hasRolled: diceResult?.hasRolled,
       });
     });
 

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -195,8 +195,10 @@ export default function initializeSocketHandler(io: Server) {
       try {
         const { row: rowColour, num } = playerChoice;
         const updatedGameState = gameLogic?.makeMove(userId, rowColour, num);
+        const moveAvailability = gameLogic?.validMoveAvailable();
+        console.log("move availability after move", moveAvailability);
 
-        const responseData = { gameState: updatedGameState };
+        const responseData = { gameState: updatedGameState, moveAvailability };
 
         io.to(lobbyId).emit("update_markedNumbers", responseData);
         console.log("Updated game state:", updatedGameState);

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -195,8 +195,8 @@ export default function initializeSocketHandler(io: Server) {
       try {
         const { row: rowColour, num } = playerChoice;
         const updatedGameState = gameLogic?.makeMove(userId, rowColour, num);
-        const moveAvailability = gameLogic?.validMoveAvailable();
-        console.log("move availability after move", moveAvailability);
+        //const moveAvailability = gameLogic?.validMoveAvailable();
+        //console.log("move availability after move", moveAvailability);
 
         const responseData = { gameState: updatedGameState, moveAvailability };
 

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -220,11 +220,13 @@ export default function initializeSocketHandler(io: Server) {
 
     socket.on("roll_dice", ({ lobbyId }) => {
       const diceResult = lobbiesMap[lobbyId].rollDice();
+      const hasRolled = lobbiesMap[lobbyId].gameLogic?.hasRolled;
       const moveAvailability =
         lobbiesMap[lobbyId].gameLogic?.validMoveAvailable();
       io.to(lobbyId).emit("dice_rolled", {
         dice: diceResult,
         moveAvailability,
+        hasRolled,
       });
     });
   });

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -194,14 +194,20 @@ export default function initializeSocketHandler(io: Server) {
 
       try {
         const { row: rowColour, num } = playerChoice;
-        const updatedGameState = gameLogic?.makeMove(userId, rowColour, num);
-        //const moveAvailability = gameLogic?.validMoveAvailable();
-        //console.log("move availability after move", moveAvailability);
+        const res = gameLogic?.makeMove(userId, rowColour, num);
 
-        const responseData = { gameState: updatedGameState, moveAvailability };
+        console.log("Updated game state:", res);
 
-        io.to(lobbyId).emit("update_markedNumbers", responseData);
-        console.log("Updated game state:", updatedGameState);
+        if (!res?.success) {
+          const responseData = { message: res?.error }
+          socket.emit("error_occured", { message: responseData })
+        }
+
+        if (res?.success) {
+          const responseData = { gameState: res.data }
+          io.to(lobbyId).emit("update_markedNumbers", responseData);
+        }
+
       } catch (err) {
         if (err instanceof Error) {
           socket.emit("error_occured", { message: err.message });

--- a/server/src/tests/models/GameBoardTemp.test.ts
+++ b/server/src/tests/models/GameBoardTemp.test.ts
@@ -9,13 +9,13 @@ describe("gameboard temp test", () => {
   });
   test("get back rows", () => {
     const rows = testGameCard.MarkedNumbers;
-    console.log(rows);
+    //console.log(rows);
     expect(rows).toEqual({ red: [], yellow: [], green: [], blue: [] });
   });
 
   test("get back numbers", () => {
     const numbers = testGameCard.Numbers;
-    console.log(numbers);
+    //console.log(numbers);
     expect(numbers).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
   });
 
@@ -35,5 +35,11 @@ describe("gameboard temp test", () => {
     testGameCard.markNumbers(rowColour.Red, 5);
     const rows = testGameCard.MarkedNumbers;
     expect(rows).toEqual({ red: [5], yellow: [], green: [], blue: [] });
+  });
+
+  test.only("get back highest and lowest marked numbers", () => {
+    testGameCard.markNumbers(rowColour.Red, 5);
+    const numbers = testGameCard.getHighestLowestMarkedNumbers();
+    expect(numbers).toEqual({ red: 5, yellow: 1, blue: 13, green: 13 });
   });
 });

--- a/server/src/tests/models/InitializePlayer.test.ts
+++ b/server/src/tests/models/InitializePlayer.test.ts
@@ -47,7 +47,7 @@ describe("initializePlayers tests", () => {
       expect(player).toBeDefined();
       expect(player.name).toBe(`player${i + 1}`);
       expect(player.serialize()).toEqual({
-        gamecard: {
+        gameCard: {
           rows: {
             blue: [],
             green: [],

--- a/server/src/tests/models/InitializePlayer.test.ts
+++ b/server/src/tests/models/InitializePlayer.test.ts
@@ -47,19 +47,22 @@ describe("initializePlayers tests", () => {
       expect(player).toBeDefined();
       expect(player.name).toBe(`player${i + 1}`);
       expect(player.serialize()).toEqual({
-        isLocked: {
-          blue: false,
-          green: false,
-          red: false,
-          yellow: false,
+        gamecard: {
+          rows: {
+            blue: [],
+            green: [],
+            red: [],
+            yellow: [],
+          },
+          isLocked: {
+            blue: false,
+            green: false,
+            red: false,
+            yellow: false,
+          },
+          penalties: [],
         },
-        penalties: 0,
-        rows: {
-          blue: [],
-          green: [],
-          red: [],
-          yellow: [],
-        },
+        hasSubmittedChoice: false,
       });
     }
   });

--- a/server/src/tests/models/LobbyClass.integration.test.ts
+++ b/server/src/tests/models/LobbyClass.integration.test.ts
@@ -1,22 +1,56 @@
 import Lobby from "../../models/LobbyClass";
 
 describe("Lobby Class integration tests", () => {
-  it("should roll dice and return dice values", () => {
-    const testLobby = new Lobby("1234");
-    testLobby.addPlayer("John");
-    testLobby.addPlayer("Fred");
+  describe("Dice roll tests", () => {
+    it("should roll dice and return dice value", () => {
+      const testLobby = new Lobby("1234");
+      testLobby.addPlayer("John");
+      testLobby.addPlayer("Fred");
 
-    testLobby.startGame();
+      testLobby.startGame();
 
-    const diceValues = testLobby.rollDice();
+      const res = testLobby.gameLogic?.rollDice();
 
-    if (!diceValues) {
-      throw new Error("Dice is undefined.");
-    }
+      if (!res) {
+        throw new Error("Dice is undefined.");
+      }
 
-    Object.values(diceValues).forEach((value) => {
-      expect(value).toBeGreaterThanOrEqual(1);
-      expect(value).toBeLessThanOrEqual(6);
+      Object.values(res.diceValues).forEach((value) => {
+        expect(value).toBeGreaterThanOrEqual(1);
+        expect(value).toBeLessThanOrEqual(6);
+      });
     });
+
+    test("hasRolled state should be true after rolling the dice", () => {
+      const testLobby = new Lobby("1234");
+      testLobby.addPlayer("John");
+      testLobby.addPlayer("Fred");
+
+      testLobby.startGame();
+
+      const res = testLobby.gameLogic?.rollDice();
+
+      if (!res) {
+        throw new Error("Dice is undefined.");
+      }
+
+      expect(res.hasRolled).toBeTruthy()
+    })
+
+    it("should return whether the active player has available moves or not", () => {
+      const testLobby = new Lobby("1234");
+      testLobby.addPlayer("John");
+      testLobby.addPlayer("Fred");
+
+      testLobby.startGame();
+
+      const res = testLobby.gameLogic?.rollDice();
+
+      if (!res) {
+        throw new Error("Dice is undefined.");
+      }
+
+      expect(res.hasAvailableMoves).toBeTruthy()
+    })
   });
 });

--- a/server/src/tests/models/PlayerClass.unit.test.ts
+++ b/server/src/tests/models/PlayerClass.unit.test.ts
@@ -4,7 +4,6 @@ import qwixxBaseGameCard from "../../models/QwixxBaseGameCard";
 
 const mockGameCard: Partial<qwixxBaseGameCard> = {
   markNumbers: jest.fn(),
-  //  getHighestLowestMarkedNumbers: jest.fn(),
 };
 
 let testPlayer: Player;
@@ -18,15 +17,25 @@ describe("Player Class tests", () => {
     expect(testPlayer.name).toEqual("testPlayer");
   });
 
-  test("submission count should increment when incrementSubmissionCount is called", () => {
-    (mockGameCard.markNumbers! as jest.Mock).mockReturnValue(true);
+  test("submission count should increment when marking a number is successful", () => {
+    (mockGameCard.markNumbers! as jest.Mock).mockReturnValue({ success: true });
 
     testPlayer.markNumber(rowColour.Red, 2);
     expect(testPlayer.submissionCount).toBe(1);
   });
 
+  test("should return an error message when marking a number is unsuccessful", () => {
+    (mockGameCard.markNumbers! as jest.Mock).mockReturnValue({
+      success: false,
+      errorMessage: "Invalid move."
+    });
+
+    const res = testPlayer.markNumber(rowColour.Red, 2);
+    expect(res).toEqual({ success: false, errorMessage: "Invalid move." })
+  })
+
   test("submission count should return to 0 after markSubmitted() call", () => {
-    (mockGameCard.markNumbers! as jest.Mock).mockReturnValue(true);
+    (mockGameCard.markNumbers! as jest.Mock).mockReturnValue({ success: true });
 
     testPlayer.markNumber(rowColour.Red, 2);
     testPlayer.markNumber(rowColour.Red, 3);
@@ -43,26 +52,4 @@ describe("Player Class tests", () => {
 
     expect(testPlayer.hasSubmittedChoice).toBeTruthy();
   });
-
-  //  test.only("returns true if hasAvailableMoves is true", () => {
-  //    const obj = {
-  //      red: 5,
-  //      yellow: 1,
-  //      blue: 13,
-  //      green: 13,
-  //    };
-  //
-  //    const validColouredNumbers = {
-  //      red: [7, 9],
-  //      yellow: [3, 4],
-  //      blue: [12, 8],
-  //      green: [11, 5],
-  //    };
-  //
-  //    (mockGameCard.getHighestLowestMarkedNumbers! as jest.Mock).mockReturnValue(
-  //      obj
-  //    );
-  //    const result = testPlayer.hasAvailableMoves(validColouredNumbers);
-  //    expect(result).toBeTruthy();
-  //  });
 });

--- a/server/src/tests/models/PlayerClass.unit.test.ts
+++ b/server/src/tests/models/PlayerClass.unit.test.ts
@@ -4,6 +4,7 @@ import qwixxBaseGameCard from "../../models/QwixxBaseGameCard";
 
 const mockGameCard: Partial<qwixxBaseGameCard> = {
   markNumbers: jest.fn(),
+  getHighestLowestMarkedNumbers: jest.fn(),
 };
 
 let testPlayer: Player;
@@ -19,10 +20,10 @@ describe("Player Class tests", () => {
 
   test("submission count should increment when incrementSubmissionCount is called", () => {
     (mockGameCard.markNumbers! as jest.Mock).mockReturnValue(true);
-   
-    testPlayer.markNumber(rowColour.Red,2);
+
+    testPlayer.markNumber(rowColour.Red, 2);
     expect(testPlayer.submissionCount).toBe(1);
-  })
+  });
 
   test("submission count should return to 0 after markSubmitted() call", () => {
     (mockGameCard.markNumbers! as jest.Mock).mockReturnValue(true);
@@ -33,7 +34,7 @@ describe("Player Class tests", () => {
 
     testPlayer.resetSubmission();
     expect(testPlayer.submissionCount).toBe(0);
-  })
+  });
 
   test("markSubmitted should set hasSubmittedChoice state", () => {
     expect(testPlayer.hasSubmittedChoice).toBeFalsy();
@@ -41,5 +42,27 @@ describe("Player Class tests", () => {
     testPlayer.markSubmitted();
 
     expect(testPlayer.hasSubmittedChoice).toBeTruthy();
-  })
+  });
+
+  test.only("returns true if hasAvailableMoves is true", () => {
+    const obj = {
+      red: 5,
+      yellow: 1,
+      blue: 13,
+      green: 13,
+    };
+
+    const validColouredNumbers = {
+      red: [7, 9],
+      yellow: [3, 4],
+      blue: [12, 8],
+      green: [11, 5],
+    };
+
+    (mockGameCard.getHighestLowestMarkedNumbers! as jest.Mock).mockReturnValue(
+      obj
+    );
+    const result = testPlayer.hasAvailableMoves(validColouredNumbers);
+    expect(result).toBeTruthy();
+  });
 });

--- a/server/src/tests/models/PlayerClass.unit.test.ts
+++ b/server/src/tests/models/PlayerClass.unit.test.ts
@@ -4,7 +4,7 @@ import qwixxBaseGameCard from "../../models/QwixxBaseGameCard";
 
 const mockGameCard: Partial<qwixxBaseGameCard> = {
   markNumbers: jest.fn(),
-  getHighestLowestMarkedNumbers: jest.fn(),
+  //  getHighestLowestMarkedNumbers: jest.fn(),
 };
 
 let testPlayer: Player;
@@ -44,25 +44,25 @@ describe("Player Class tests", () => {
     expect(testPlayer.hasSubmittedChoice).toBeTruthy();
   });
 
-  test.only("returns true if hasAvailableMoves is true", () => {
-    const obj = {
-      red: 5,
-      yellow: 1,
-      blue: 13,
-      green: 13,
-    };
-
-    const validColouredNumbers = {
-      red: [7, 9],
-      yellow: [3, 4],
-      blue: [12, 8],
-      green: [11, 5],
-    };
-
-    (mockGameCard.getHighestLowestMarkedNumbers! as jest.Mock).mockReturnValue(
-      obj
-    );
-    const result = testPlayer.hasAvailableMoves(validColouredNumbers);
-    expect(result).toBeTruthy();
-  });
+  //  test.only("returns true if hasAvailableMoves is true", () => {
+  //    const obj = {
+  //      red: 5,
+  //      yellow: 1,
+  //      blue: 13,
+  //      green: 13,
+  //    };
+  //
+  //    const validColouredNumbers = {
+  //      red: [7, 9],
+  //      yellow: [3, 4],
+  //      blue: [12, 8],
+  //      green: [11, 5],
+  //    };
+  //
+  //    (mockGameCard.getHighestLowestMarkedNumbers! as jest.Mock).mockReturnValue(
+  //      obj
+  //    );
+  //    const result = testPlayer.hasAvailableMoves(validColouredNumbers);
+  //    expect(result).toBeTruthy();
+  //  });
 });

--- a/server/src/tests/models/QwixxBaseGameCard.test.ts
+++ b/server/src/tests/models/QwixxBaseGameCard.test.ts
@@ -37,9 +37,15 @@ describe("gameboard temp test", () => {
     expect(rows).toEqual({ red: [5], yellow: [], green: [], blue: [] });
   });
 
-  test.only("get back highest and lowest marked numbers", () => {
-    testGameCard.markNumbers(rowColour.Red, 5);
-    const numbers = testGameCard.getHighestLowestMarkedNumbers();
-    expect(numbers).toEqual({ red: 5, yellow: 1, blue: 13, green: 13 });
+  test("return true if there are available moves based on current gamecard", () => {
+    const obj = {
+      [rowColour.Red]: [4, 8],
+      [rowColour.Yellow]: [5, 10],
+      [rowColour.Blue]: [10, 6],
+      [rowColour.Green]: [11, 7],
+    };
+
+    const res = testGameCard.hasAvailableMoves(obj);
+    expect(res).toBeTruthy();
   });
 });

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -49,23 +49,25 @@ describe("Qwixx Logic integration tests:", () => {
       );
     });
 
-    it("should make a move and return the correct result", () => {
+    it.only("should make a move and return the correct result", () => {
       const result = testGame.rollDice();
-      const whiteDiceSum = result.white1 + result.white2;
-      const gameState = testGame.makeMove("test-player1", "red", whiteDiceSum);
-      if (typeof gameState === "object") {
-        expect(gameState.players).toHaveProperty("test-player1");
-        expect(gameState.players).toHaveProperty("test-player2");
-        expect(gameState.players["test-player1"].gamecard).toHaveProperty(
+      const whiteDiceSum = result.diceValues.white1 + result.diceValues.white2;
+
+      const gameState = testGame.makeMove("test-player2", "red", whiteDiceSum);
+
+      if (gameState.success) {
+        expect(gameState.data.players).toHaveProperty("test-player1")
+        expect(gameState.data.players).toHaveProperty("test-player2");
+        expect(gameState.data.players["test-player1"].gameCard).toHaveProperty(
           "penalties",
           []
         );
-        expect(gameState.players["test-player2"].gamecard).toHaveProperty(
+        expect(gameState.data.players["test-player2"].gameCard).toHaveProperty(
           "penalties",
           []
         );
 
-        expect(gameState.dice).toMatchObject({
+        expect(gameState.data.dice).toMatchObject({
           white1: expect.any(Number),
           white2: expect.any(Number),
           red: expect.any(Number),
@@ -82,14 +84,14 @@ describe("Qwixx Logic integration tests:", () => {
       console.log(result);
       expect(initialGameState.activePlayer).toBe("test-player1");
 
-      const firstMoveState = testGame.makeMove("test-player1", "red", 5);
-      expect(firstMoveState.activePlayer).toBe("test-player1");
+      //  const firstMoveState = testGame.makeMove("test-player1", "red", 5);
+      //  expect(firstMoveState.activePlayer).toBe("test-player1");
 
-      const secondMoveState = testGame.makeMove("test-player1", "red", 7);
-      expect(secondMoveState.activePlayer).toBe("test-player1");
+      //  const secondMoveState = testGame.makeMove("test-player1", "red", 7);
+      //  expect(secondMoveState.activePlayer).toBe("test-player1");
 
-      const finalMoveState = testGame.makeMove("test-player2", "blue", 5);
-      expect(finalMoveState.activePlayer).toBe("test-player2");
+      //  const finalMoveState = testGame.makeMove("test-player2", "blue", 5);
+      //  expect(finalMoveState.activePlayer).toBe("test-player2");
     });
 
     test("when the game goes to the next turn, all players' submission state is reset", () => {
@@ -209,23 +211,23 @@ describe("Qwixx Logic integration tests:", () => {
       }
     );
 
-    test("active-player can mark a number that equals the sum of a white and a coloured die", () => {
-      const diceResults = testGame.rollDice();
-      const firstNumber = diceResults.white1 + diceResults.white2;
-      testGame.makeMove("test-player1", "blue", firstNumber);
+    //test("active-player can mark a number that equals the sum of a white and a coloured die", () => {
+    //  const diceResults = testGame.rollDice();
+    //  const firstNumber = diceResults.white1 + diceResults.white2;
+    //  testGame.makeMove("test-player1", "blue", firstNumber);
 
-      const secondNumber = diceResults.white1 + diceResults.red;
+    //  const secondNumber = diceResults.white1 + diceResults.red;
 
-      const validNumbers = mockDice.validColouredNumbers;
+    //  const validNumbers = mockDice.validColouredNumbers;
 
-      expect(validNumbers["red"]?.includes(secondNumber)).toBeTruthy;
+    //  expect(validNumbers["red"]?.includes(secondNumber)).toBeTruthy;
 
-      expect(() =>
-        testGame.makeMove("test-player1", "red", secondNumber)
-      ).not.toThrow(
-        "Number selected doesn't equal to sum of white die and coloured die."
-      );
-    });
+    //  expect(() =>
+    //    testGame.makeMove("test-player1", "red", secondNumber)
+    //  ).not.toThrow(
+    //    "Number selected doesn't equal to sum of white die and coloured die."
+    //  );
+    //});
 
     test("current player can end their turn without submitting a move", () => {
       testGame.rollDice();

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -56,13 +56,13 @@ describe("Qwixx Logic integration tests:", () => {
       if (typeof gameState === "object") {
         expect(gameState.players).toHaveProperty("test-player1");
         expect(gameState.players).toHaveProperty("test-player2");
-        expect(gameState.players["test-player1"]).toHaveProperty(
+        expect(gameState.players["test-player1"].gamecard).toHaveProperty(
           "penalties",
-          0
+          []
         );
-        expect(gameState.players["test-player2"]).toHaveProperty(
+        expect(gameState.players["test-player2"].gamecard).toHaveProperty(
           "penalties",
-          0
+          []
         );
 
         expect(gameState.dice).toMatchObject({
@@ -81,8 +81,6 @@ describe("Qwixx Logic integration tests:", () => {
       const initialGameState = testGame.serialize();
       console.log(result);
       expect(initialGameState.activePlayer).toBe("test-player1");
-
-      
 
       const firstMoveState = testGame.makeMove("test-player1", "red", 5);
       expect(firstMoveState.activePlayer).toBe("test-player1");

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -210,4 +210,55 @@ describe("Qwixx Logic tests", () => {
     expect(isMoveAvailable["player1"]).toBe(false);
     expect(isMoveAvailable["player2"]).toBe(true);
   });
+
+  describe("processPenalthy method tests", () => {
+    it("should add a penalty to the player and mark them as submitted", () => {
+      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+      const player1AddPenaltySpy = jest.spyOn(player1Mock, "addPenalty");
+      const player1MarkSubmittedSpy = jest.spyOn(player1Mock, "markSubmitted");
+
+      testGame.processPenalty("player1");
+
+      expect(player1AddPenaltySpy).toHaveBeenCalled();
+      expect(player1MarkSubmittedSpy).toHaveBeenCalled();
+    });
+
+    it("should throw an error if player not found", () => {
+      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+      expect(() => testGame.processPenalty("player3")).toThrow(
+        "Player not found"
+      );
+    });
+
+    it("should add a penalty to the players gamecard", () => {
+      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+
+      const serializedData = {
+        gamecard: {
+          rows: {
+            red: [],
+            yellow: [],
+            green: [],
+            blue: [],
+          },
+          isLocked: {
+            red: false,
+            yellow: false,
+            green: false,
+            blue: false,
+          },
+          penalties: [1],
+        },
+        hasSubmittedChoice: false,
+      };
+
+      jest.spyOn(player1Mock, "serialize").mockReturnValue(serializedData);
+
+      const addPenaltySpy = jest.spyOn(player1Mock.gameCard, "addPenalty");
+      const result = testGame.processPenalty("player1");
+
+      expect(addPenaltySpy).toHaveBeenCalled();
+      expect(player1Mock.serialize()).toEqual(serializedData);
+    });
+  });
 });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -36,6 +36,24 @@ jest.spyOn(fakeDice, "validColouredNumbers", "get").mockReturnValue({
   [DiceColour.Blue]: [10, 10],
 });
 
+jest
+  .spyOn(gameCardMock1, "getHighestMarkedNumber")
+  .mockImplementation((row) => {
+    if (row === "red") return 9;
+    if (row === "yellow") return 8;
+    if (row === "green") return 8;
+    if (row === "blue") return 8;
+    return 2;
+  });
+
+jest.spyOn(gameCardMock1, "getLowestMarkedNumber").mockImplementation((row) => {
+  if (row === "red") return 2;
+  if (row === "yellow") return 2;
+  if (row === "green") return 5;
+  if (row === "blue") return 4;
+  return 12;
+});
+
 const playersArrayMock = [player1Mock, player2Mock];
 
 describe("Qwixx Logic tests", () => {
@@ -139,5 +157,30 @@ describe("Qwixx Logic tests", () => {
 
     expect(isMoveAvailable["player1"]).toBe(true);
     expect(isMoveAvailable["player2"]).toBe(true);
+  });
+
+  test("active-player marking a number that equals the sum of a white dice but lower than highest marked red row will throw an error", () => {
+    const originalImplementation = gameCardMock1.getHighestMarkedNumber;
+
+    jest
+      .spyOn(gameCardMock1, "getHighestMarkedNumber")
+      .mockImplementation((row) => {
+        if (row === "red") return 11;
+        if (row === "yellow") return 8;
+        if (row === "green") return 8;
+        if (row === "blue") return 8;
+        return 2;
+      });
+
+    const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+    testGame.rollDice();
+
+    expect(() => {
+      testGame.makeMove("player1", "red", 10);
+    }).toThrow("Number must be above the last marked number");
+
+    jest
+      .spyOn(gameCardMock1, "getHighestMarkedNumber")
+      .mockImplementation(originalImplementation);
   });
 });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -212,7 +212,7 @@ describe("Qwixx Logic tests", () => {
   describe("processPenalthy method tests", () => {
     it("should add a penalty to the player and mark them as submitted", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      const player1AddPenaltySpy = jest.spyOn(player1Mock, "addPenalty");
+      const player1AddPenaltySpy = jest.spyOn(gameCardMock1, "addPenalty");
       const player1MarkSubmittedSpy = jest.spyOn(player1Mock, "markSubmitted");
 
       testGame.processPenalty("player1");
@@ -231,32 +231,34 @@ describe("Qwixx Logic tests", () => {
     it("should add a penalty to the players gamecard", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
 
-      const serializedData = {
-        gamecard: {
-          rows: {
-            red: [],
-            yellow: [],
-            green: [],
-            blue: [],
-          },
-          isLocked: {
-            red: false,
-            yellow: false,
-            green: false,
-            blue: false,
-          },
-          penalties: [1],
-        },
-        hasSubmittedChoice: false,
-      };
+      // TODO: explain why this test isn't applicable in this unit test
 
-      jest.spyOn(player1Mock, "serialize").mockReturnValue(serializedData);
+      //      const serializedData = {
+      //        gamecard: {
+      //          rows: {
+      //            red: [],
+      //            yellow: [],
+      //            green: [],
+      //            blue: [],
+      //          },
+      //          isLocked: {
+      //            red: false,
+      //            yellow: false,
+      //            green: false,
+      //            blue: false,
+      //          },
+      //          penalties: [1],
+      //        },
+      //        hasSubmittedChoice: false,
+      //      };
+
+      // jest.spyOn(player1Mock, "serialize").mockReturnValue(serializedData);
 
       const addPenaltySpy = jest.spyOn(player1Mock.gameCard, "addPenalty");
-      const result = testGame.processPenalty("player1");
+      testGame.processPenalty("player1");
 
       expect(addPenaltySpy).toHaveBeenCalled();
-      expect(player1Mock.serialize()).toEqual(serializedData);
+      //expect(player1Mock.serialize()).toEqual(serializedData);
     });
   });
 });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -183,4 +183,31 @@ describe("Qwixx Logic tests", () => {
       .spyOn(gameCardMock1, "getHighestMarkedNumber")
       .mockImplementation(originalImplementation);
   });
+
+  test("should throw error when trying to mark blue 10, if gamecard has no valid moves", () => {
+    jest
+      .spyOn(gameCardMock1, "getHighestMarkedNumber")
+      .mockImplementation((row) => {
+        if (row === "red" || row === "yellow") return 11;
+        return 10;
+      });
+
+    jest
+      .spyOn(gameCardMock1, "getLowestMarkedNumber")
+      .mockImplementation((row) => {
+        if (row === "green" || row === "blue") return 6;
+        return 4;
+      });
+
+    const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+    testGame.rollDice();
+    const isMoveAvailable = testGame.validMoveAvailable();
+
+    expect(() => {
+      testGame.makeMove("player1", "blue", 10);
+    }).toThrow("Number must be below the last marked number");
+
+    expect(isMoveAvailable["player1"]).toBe(false);
+    expect(isMoveAvailable["player2"]).toBe(true);
+  });
 });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -4,6 +4,7 @@ import qwixxBaseGameCard from "../../models/QwixxBaseGameCard";
 import Dice from "../../models/DiceClass";
 import { DiceColour } from "../../enums/DiceColours";
 import SixSidedDie from "../../models/SixSidedDieClass";
+import { rowColour } from "../../enums/rowColours";
 
 const MockedGameCardClass = qwixxBaseGameCard as jest.Mocked<
   typeof qwixxBaseGameCard
@@ -109,7 +110,7 @@ describe("Qwixx Logic tests", () => {
       );
     }
   );
-  
+
   test.each([
     ["red", 10],
     ["yellow", 10],
@@ -130,4 +131,13 @@ describe("Qwixx Logic tests", () => {
       );
     }
   );
+
+  test("moveAvailability should return true if gameCard is empty", () => {
+    const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+    testGame.rollDice();
+    const isMoveAvailable = testGame.validMoveAvailable();
+
+    expect(isMoveAvailable["player1"]).toBe(true);
+    expect(isMoveAvailable["player2"]).toBe(true);
+  });
 });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -150,13 +150,11 @@ describe("Qwixx Logic tests", () => {
     }
   );
 
-  test("moveAvailability should return true if gameCard is empty", () => {
+  test.only("moveAvailability should return true if gameCard is empty", () => {
     const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-    testGame.rollDice();
-    const isMoveAvailable = testGame.validMoveAvailable();
+    const res = testGame.rollDice();
 
-    expect(isMoveAvailable["player1"]).toBe(true);
-    expect(isMoveAvailable["player2"]).toBe(true);
+    expect(res.hasAvailableMoves).toBeTruthy();
   });
 
   test("active-player marking a number that equals the sum of a white dice but lower than highest marked red row will throw an error", () => {
@@ -201,14 +199,14 @@ describe("Qwixx Logic tests", () => {
 
     const testGame = new QwixxLogic(playersArrayMock, fakeDice);
     testGame.rollDice();
-    const isMoveAvailable = testGame.validMoveAvailable();
+    //const isMoveAvailable = testGame.validMoveAvailable();
 
     expect(() => {
       testGame.makeMove("player1", "blue", 10);
     }).toThrow("Number must be below the last marked number");
 
-    expect(isMoveAvailable["player1"]).toBe(false);
-    expect(isMoveAvailable["player2"]).toBe(true);
+    //expect(isMoveAvailable["player1"]).toBe(false);
+    //expect(isMoveAvailable["player2"]).toBe(true);
   });
 
   describe("processPenalthy method tests", () => {

--- a/server/src/tests/socketHandlers/socketHandlers.integration.test.ts
+++ b/server/src/tests/socketHandlers/socketHandlers.integration.test.ts
@@ -115,7 +115,7 @@ describe("socket event handler test", () => {
         (data: { path: string; gameState: any }) => {
           expect(data.path).toBe("/game/1234");
           expect(data.gameState.players.clientSocket1).toEqual({
-            gamecard: {
+            gameCard: {
               rows: { red: [], yellow: [], green: [], blue: [] },
               isLocked: {
                 red: false,
@@ -128,7 +128,7 @@ describe("socket event handler test", () => {
             hasSubmittedChoice: false,
           });
           expect(data.gameState.players.clientSocket2).toEqual({
-            gamecard: {
+            gameCard: {
               rows: { red: [], yellow: [], green: [], blue: [] },
               isLocked: {
                 red: false,

--- a/server/src/tests/socketHandlers/socketHandlers.integration.test.ts
+++ b/server/src/tests/socketHandlers/socketHandlers.integration.test.ts
@@ -97,7 +97,6 @@ describe("socket event handler test", () => {
     });
 
     it("Can start a game", (done) => {
-     
       clientSocket1.emit("create_lobby", "clientSocket1", () => {
         clientSocket2.emit(
           "join_lobby",
@@ -116,14 +115,30 @@ describe("socket event handler test", () => {
         (data: { path: string; gameState: any }) => {
           expect(data.path).toBe("/game/1234");
           expect(data.gameState.players.clientSocket1).toEqual({
-            rows: { red: [], yellow: [], green: [], blue: [] },
-            isLocked: { red: false, yellow: false, green: false, blue: false },
-            penalties: 0,
+            gamecard: {
+              rows: { red: [], yellow: [], green: [], blue: [] },
+              isLocked: {
+                red: false,
+                yellow: false,
+                green: false,
+                blue: false,
+              },
+              penalties: [],
+            },
+            hasSubmittedChoice: false,
           });
-           expect(data.gameState.players.clientSocket2).toEqual({
-            rows: { red: [], yellow: [], green: [], blue: [] },
-            isLocked: { red: false, yellow: false, green: false, blue: false },
-            penalties: 0,
+          expect(data.gameState.players.clientSocket2).toEqual({
+            gamecard: {
+              rows: { red: [], yellow: [], green: [], blue: [] },
+              isLocked: {
+                red: false,
+                yellow: false,
+                green: false,
+                blue: false,
+              },
+              penalties: [],
+            },
+            hasSubmittedChoice: false,
           });
           done();
         }

--- a/server/src/tests/socketHandlers/socketHandlers.unit.test.ts
+++ b/server/src/tests/socketHandlers/socketHandlers.unit.test.ts
@@ -24,6 +24,8 @@ jest.spyOn(Dice.prototype, "diceValues", "get").mockReturnValue({
   blue: 5,
 });
 
+jest.spyOn(Dice.prototype, "whiteDiceSum", "get").mockReturnValue(10);
+
 /*
  * Mock the generateUniqueRoomId function to return controlled values for tests.
  * This ensures that tests using this mock do not generate random values.
@@ -238,10 +240,10 @@ describe("socket event handler test", () => {
           gameStartedData.gameState.players["clientSocket1"]
         ).toBeDefined();
         expect(
-          gameStartedData.gameState.players["clientSocket1"].gamecard.rows
+          gameStartedData.gameState.players["clientSocket1"].gameCard.rows
         ).toBeTruthy();
         expect(
-          gameStartedData.gameState.players["clientSocket1"].gamecard.rows
+          gameStartedData.gameState.players["clientSocket1"].gameCard.rows
         ).toEqual({
           red: [],
           yellow: [],
@@ -253,10 +255,10 @@ describe("socket event handler test", () => {
           gameStartedData.gameState.players["clientSocket2"]
         ).toBeDefined();
         expect(
-          gameStartedData.gameState.players["clientSocket2"].gamecard.rows
+          gameStartedData.gameState.players["clientSocket2"].gameCard.rows
         ).toBeTruthy();
         expect(
-          gameStartedData.gameState.players["clientSocket2"].gamecard.rows
+          gameStartedData.gameState.players["clientSocket2"].gameCard.rows
         ).toEqual({
           red: [],
           yellow: [],
@@ -309,7 +311,7 @@ describe("socket event handler test", () => {
 
         const player2 = updatedGameState.gameState.players.clientSocket2;
         expect(player2).toEqual({
-          gamecard: {
+          gameCard: {
             rows: { red: [10], yellow: [], green: [], blue: [] },
             isLocked: { red: false, yellow: false, green: false, blue: false },
             penalties: [],

--- a/server/src/tests/socketHandlers/socketHandlers.unit.test.ts
+++ b/server/src/tests/socketHandlers/socketHandlers.unit.test.ts
@@ -34,7 +34,7 @@ const generateUniqueRoomIdMock = generateUniqueRoomId as jest.MockedFunction<
 
 /**
  * @param {ServerSocket | ClientSocket} socket
- * @param {string} event 
+ * @param {string} event
  * @returns {Promise<any>}
  * @description
  * We can use this utility funciton to make our test "act" more synchronous.
@@ -238,31 +238,31 @@ describe("socket event handler test", () => {
           gameStartedData.gameState.players["clientSocket1"]
         ).toBeDefined();
         expect(
-          gameStartedData.gameState.players["clientSocket1"].rows
+          gameStartedData.gameState.players["clientSocket1"].gamecard.rows
         ).toBeTruthy();
-        expect(gameStartedData.gameState.players["clientSocket1"].rows).toEqual(
-          {
-            red: [],
-            yellow: [],
-            green: [],
-            blue: [],
-          }
-        );
+        expect(
+          gameStartedData.gameState.players["clientSocket1"].gamecard.rows
+        ).toEqual({
+          red: [],
+          yellow: [],
+          green: [],
+          blue: [],
+        });
 
         expect(
           gameStartedData.gameState.players["clientSocket2"]
         ).toBeDefined();
         expect(
-          gameStartedData.gameState.players["clientSocket2"].rows
+          gameStartedData.gameState.players["clientSocket2"].gamecard.rows
         ).toBeTruthy();
-        expect(gameStartedData.gameState.players["clientSocket2"].rows).toEqual(
-          {
-            red: [],
-            yellow: [],
-            green: [],
-            blue: [],
-          }
-        );
+        expect(
+          gameStartedData.gameState.players["clientSocket2"].gamecard.rows
+        ).toEqual({
+          red: [],
+          yellow: [],
+          green: [],
+          blue: [],
+        });
       });
 
       test("can mark a number", async () => {
@@ -309,9 +309,12 @@ describe("socket event handler test", () => {
 
         const player2 = updatedGameState.gameState.players.clientSocket2;
         expect(player2).toEqual({
-          rows: { red: [10], yellow: [], green: [], blue: [] },
-          isLocked: { red: false, yellow: false, green: false, blue: false },
-          penalties: 0,
+          gamecard: {
+            rows: { red: [10], yellow: [], green: [], blue: [] },
+            isLocked: { red: false, yellow: false, green: false, blue: false },
+            penalties: [],
+          },
+          hasSubmittedChoice: true,
         });
       });
     });


### PR DESCRIPTION
## Description
- Seperated logic for moveValidation and makeMove 
- Added validation logic for checking if selected numbers are above or below last checked number 
- Added addPenalty method to player and gamecard classes 
- Conditionally rendered penalty or moveConfirmation based on availablevalidMoves and hasSubmitted variables 
- Added handlePenalty event listener to update gamestate if no moves available 
- Added logic on front end to update checkbox if penalty incurred. Also disabled checkout to stop players interacting direclty with it 
- see ticket #44 

## Why:
- The game rule dictates that the active player must take a penalty if they don't have an available number to mark on their turn.
- To make it more user-friendly, we've incorporated a method that checks the rolled dice values against the player's game card state. 
- It returns a boolean for whether they have an available move or not.
- If there isn't, the player would be presented with a button for accepting a penalty. 

# How:
- Whilst working on the code, we found some areas that needed refactoring.
- We moved some of the making-a-move logic into the game card class as the responsibility is best held there.
- This also meant the script could be used for checking available moves for the active player upon dice roll and during a move submission. 
- This helped made the code more modular and re-useable. It also meant the classes are less tightly coupled. 