### PR TITLE
51/feat/add end turn event and button

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -91,8 +91,8 @@ function App() {
     };
 
     const onTurnEnded = (data: { gameState: QwixxLogic }) => {
+      console.log(gameState?.players)
       setGameState(data.gameState);
-      //console.log("turn ended", data );
     }
 
     const handleDiceRolled = (data: { diceValues: any, hasAvailableMoves: boolean, hasRolled: boolean }) => {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -90,10 +90,10 @@ function App() {
       console.log("data received from backend", data);
     };
 
-    //const endTurn = (data: {gameState: QwixxLogic}) => {
-    //setGameState(data.gameState);
-    //console.log("turn ended", data );
-    //}
+    const onTurnEnded = (data: { gameState: QwixxLogic }) => {
+      setGameState(data.gameState);
+      //console.log("turn ended", data );
+    }
 
     const handleDiceRolled = (data: { diceValues: any, hasAvailableMoves: boolean, hasRolled: boolean }) => {
       setGameState((prevState) => {
@@ -134,7 +134,7 @@ function App() {
     socket.on("update_markedNumbers", updateMarkedNumbers);
     socket.on("dice_rolled", handleDiceRolled);
     socket.on("penalty_processed", updatePenalty);
-    //socket.on("turn_ended", endTurn);
+    socket.on("turn_ended", onTurnEnded);
 
     return () => {
       socket.off("connect");
@@ -148,7 +148,7 @@ function App() {
       socket.off("update_markedNumbers");
       socket.off("dice_rolled");
       socket.off("penalty_processed");
-      //socket.off("turn_ended");
+      socket.off("turn_ended");
     };
   }, []);
 

--- a/client/src/components/GameCard/GameCard.tsx
+++ b/client/src/components/GameCard/GameCard.tsx
@@ -26,7 +26,7 @@ const GameCard: React.FC<IGameCard> = ({ member, isOpponent, gameCardData, cellC
   //};
 
   const renderPenaltyCheckbox = (number: number) => {
-    console.log(gameCardData)
+    //console.log(gameCardData)
     const isPenaltyChecked = gameCardData.penalties?.includes(number);
 
     return isOpponent ? (

--- a/client/src/pages/GamePage/GamePage.tsx
+++ b/client/src/pages/GamePage/GamePage.tsx
@@ -42,9 +42,9 @@ export const Game: React.FC<IGameProps> = ({
     setPlayerChoice({ row: rowColour, num });
   };
 
-  useEffect(() => {
-    console.log(playerChoice);
-  }, [playerChoice]);
+  //  useEffect(() => {
+  //    console.log(playerChoice);
+  //  }, [playerChoice]);
   // if(!gameState){
   //     return <div>Loading...</div>;
   // }
@@ -67,7 +67,7 @@ export const Game: React.FC<IGameProps> = ({
 
   const handleNumberSelection = () => {
     socket.emit("mark_numbers", { lobbyId, userId, playerChoice });
-    console.log("player's choice:", playerChoice);
+    //console.log("player's choice:", playerChoice);
   }
 
   const handlePenalty = () => {
@@ -83,6 +83,8 @@ export const Game: React.FC<IGameProps> = ({
   const hasRolled = gameState.hasRolled;
   const activePlayer = gameState.activePlayer;
 
+  console.log("active player:", activePlayer)
+  console.log("has rolled:", hasRolled)
   console.log("player has moves:", hasAvailableMoves);
 
 
@@ -124,7 +126,7 @@ export const Game: React.FC<IGameProps> = ({
             gameCardData={gameState.players[userId].gameCard}
             cellClick={handleCellClick}
           />
-          {!hasAvailableMoves && !hasSubmitted && hasRolled && activePlayer ? (
+          {!hasAvailableMoves && !hasSubmitted && hasRolled && activePlayer === userId ? (
             <button className="penalty-btn" onClick={handlePenalty}>Accept Penalty</button>
           ) :
             (<button onClick={handleNumberSelection} disabled={hasSubmitted}>Confirm</button>)

--- a/client/src/pages/GamePage/GamePage.tsx
+++ b/client/src/pages/GamePage/GamePage.tsx
@@ -129,9 +129,8 @@ export const Game: React.FC<IGameProps> = ({
           ) :
             (<button onClick={handleNumberSelection} disabled={hasSubmitted}>Confirm</button>)
           }
-          {/* Disable button when dice hasn't been rolled*/}
-          {/* Disable button after player has submitted*/}
-          <button className="" onClick={handleEndTurn}>End Turn</button>
+          {/* For ending a turn even if there are available moves */}
+          <button className="" onClick={handleEndTurn} disabled={hasSubmitted || !hasRolled}>End Turn</button>
         </div>
       </div>
     </div>

--- a/client/src/pages/GamePage/GamePage.tsx
+++ b/client/src/pages/GamePage/GamePage.tsx
@@ -74,6 +74,10 @@ export const Game: React.FC<IGameProps> = ({
     socket.emit("submit_penalty", { userId, lobbyId });
   }
 
+  const handleEndTurn = () => {
+    socket.emit("end_turn", { lobbyId, userId })
+  }
+
   const hasSubmitted = gameState.players[userId].hasSubmittedChoice;
   const hasAvailableMoves = availableMoves;
   const hasRolled = gameState.hasRolled;
@@ -125,7 +129,9 @@ export const Game: React.FC<IGameProps> = ({
           ) :
             (<button onClick={handleNumberSelection} disabled={hasSubmitted}>Confirm</button>)
           }
-
+          {/* Disable button when dice hasn't been rolled*/}
+          {/* Disable button after player has submitted*/}
+          <button className="" onClick={handleEndTurn}>End Turn</button>
         </div>
       </div>
     </div>

--- a/client/tests/pages/GamePage/GamePage.test.tsx
+++ b/client/tests/pages/GamePage/GamePage.test.tsx
@@ -7,77 +7,10 @@ import "@testing-library/jest-dom";
 // import { MemoryRouter } from "react-router-dom";
 import { socket } from "../../../src/services/socketServices";
 //const user = userEvent.setup();
+import { initialGameState, hasRolledGameState, user1HasSubmittedState } from "./__fixtures__/gameStates";
 
 const lobbyIdMock = "1234";
 const membersArrayMock = ["testUser1", "testUser2", "testUser3"];
-const gameState = {
-  players: {
-    testUser1: {
-      gameCard: {
-        rows: {
-          red: [],
-          yellow: [],
-          green: [],
-          blue: [],
-        },
-        isLocked: {
-          red: false,
-          yellow: false,
-          green: false,
-          blue: false,
-        },
-        penalties: [],
-      },
-      hasSubmittedChoice: false,
-    },
-    testUser2: {
-      gameCard: {
-        rows: {
-          red: [],
-          yellow: [],
-          green: [],
-          blue: [],
-        },
-        isLocked: {
-          red: false,
-          yellow: false,
-          green: false,
-          blue: false,
-        },
-        penalties: [],
-      },
-      hasSubmittedChoice: false,
-    },
-    testUser3: {
-      gameCard: {
-        rows: {
-          red: [],
-          yellow: [],
-          green: [],
-          blue: [],
-        },
-        isLocked: {
-          red: false,
-          yellow: false,
-          green: false,
-          blue: false,
-        },
-        penalties: [],
-      },
-      hasSubmittedChoice: false,
-    },
-  },
-  dice: {
-    white1: 1,
-    white2: 2,
-    red: 3,
-    yellow: 4,
-    green: 5,
-    blue: 6,
-  },
-  activePlayer: "testUser1",
-  hasRolled: true,
-};
 
 describe("Game Page Unit Test:", () => {
   it("renders the page", () => {
@@ -87,7 +20,7 @@ describe("Game Page Unit Test:", () => {
         userId={"testUser1"}
         members={membersArrayMock}
         lobbyId={lobbyIdMock}
-        gameState={gameState}
+        gameState={hasRolledGameState}
         availableMoves={true}
       />
     );
@@ -111,21 +44,57 @@ describe("Game Page Unit Test:", () => {
     expect(playerGameCard.length).toBe(1);
   });
 
-  test.only("renders end turn button", () => {
+  test("end turn button should enabled when dice has been rolled", () => {
     render(
       <GamePage
         socket={socket}
         userId={"testUser1"}
         members={membersArrayMock}
         lobbyId={lobbyIdMock}
-        gameState={gameState}
+        gameState={hasRolledGameState}
         availableMoves={true}
       />
     );
 
     const endTurnBtn = screen.getByText("End Turn")
     expect(endTurnBtn).toBeVisible()
+    expect(endTurnBtn).not.toBeDisabled()
   })
+
+  test("end turn button should be disabled when dice hasn't been rolled", () => {
+    render(
+      <GamePage
+        socket={socket}
+        userId={"testUser1"}
+        members={membersArrayMock}
+        lobbyId={lobbyIdMock}
+        gameState={initialGameState}
+        availableMoves={true}
+      />
+    );
+
+    const endTurnBtn = screen.getByText("End Turn")
+    expect(endTurnBtn).toBeVisible()
+    expect(endTurnBtn).toBeDisabled()
+  })
+
+  test("end turn button should be disabled if player has finished their turn", () => {
+    render(
+      <GamePage
+        socket={socket}
+        userId={"testUser1"}
+        members={membersArrayMock}
+        lobbyId={lobbyIdMock}
+        gameState={user1HasSubmittedState}
+        availableMoves={true}
+      />
+    );
+
+    const endTurnBtn = screen.getByText("End Turn")
+    expect(endTurnBtn).toBeVisible()
+    expect(endTurnBtn).toBeDisabled()
+  })
+
   test("confirm button should render if there is an available move", () => {
     render(
       <GamePage
@@ -133,7 +102,7 @@ describe("Game Page Unit Test:", () => {
         userId={"testUser1"}
         members={membersArrayMock}
         lobbyId={lobbyIdMock}
-        gameState={gameState}
+        gameState={hasRolledGameState}
         availableMoves={true}
       />
     );
@@ -149,7 +118,7 @@ describe("Game Page Unit Test:", () => {
         userId={"testUser1"}
         members={membersArrayMock}
         lobbyId={lobbyIdMock}
-        gameState={gameState}
+        gameState={hasRolledGameState}
         availableMoves={false}
       />
     );

--- a/client/tests/pages/GamePage/GamePage.test.tsx
+++ b/client/tests/pages/GamePage/GamePage.test.tsx
@@ -111,6 +111,21 @@ describe("Game Page Unit Test:", () => {
     expect(playerGameCard.length).toBe(1);
   });
 
+  test.only("renders end turn button", () => {
+    render(
+      <GamePage
+        socket={socket}
+        userId={"testUser1"}
+        members={membersArrayMock}
+        lobbyId={lobbyIdMock}
+        gameState={gameState}
+        availableMoves={true}
+      />
+    );
+
+    const endTurnBtn = screen.getByText("End Turn")
+    expect(endTurnBtn).toBeVisible()
+  })
   test("confirm button should render if there is an available move", () => {
     render(
       <GamePage

--- a/client/tests/pages/GamePage/__fixtures__/gameStates.ts
+++ b/client/tests/pages/GamePage/__fixtures__/gameStates.ts
@@ -1,0 +1,206 @@
+export const initialGameState = {
+	players: {
+		testUser1: {
+			gameCard: {
+				rows: {
+					red: [],
+					yellow: [],
+					green: [],
+					blue: [],
+				},
+				isLocked: {
+					red: false,
+					yellow: false,
+					green: false,
+					blue: false,
+				},
+				penalties: [],
+			},
+			hasSubmittedChoice: false,
+		},
+		testUser2: {
+			gameCard: {
+				rows: {
+					red: [],
+					yellow: [],
+					green: [],
+					blue: [],
+				},
+				isLocked: {
+					red: false,
+					yellow: false,
+					green: false,
+					blue: false,
+				},
+				penalties: [],
+			},
+			hasSubmittedChoice: false,
+		},
+		testUser3: {
+			gameCard: {
+				rows: {
+					red: [],
+					yellow: [],
+					green: [],
+					blue: [],
+				},
+				isLocked: {
+					red: false,
+					yellow: false,
+					green: false,
+					blue: false,
+				},
+				penalties: [],
+			},
+			hasSubmittedChoice: false,
+		},
+	},
+	dice: {
+		white1: 1,
+		white2: 1,
+		red: 1,
+		yellow: 1,
+		green: 1,
+		blue: 1,
+	},
+	activePlayer: "testUser1",
+	hasRolled: false,
+}
+
+export const hasRolledGameState = {
+	players: {
+		testUser1: {
+			gameCard: {
+				rows: {
+					red: [],
+					yellow: [],
+					green: [],
+					blue: [],
+				},
+				isLocked: {
+					red: false,
+					yellow: false,
+					green: false,
+					blue: false,
+				},
+				penalties: [],
+			},
+			hasSubmittedChoice: false,
+		},
+		testUser2: {
+			gameCard: {
+				rows: {
+					red: [],
+					yellow: [],
+					green: [],
+					blue: [],
+				},
+				isLocked: {
+					red: false,
+					yellow: false,
+					green: false,
+					blue: false,
+				},
+				penalties: [],
+			},
+			hasSubmittedChoice: false,
+		},
+		testUser3: {
+			gameCard: {
+				rows: {
+					red: [],
+					yellow: [],
+					green: [],
+					blue: [],
+				},
+				isLocked: {
+					red: false,
+					yellow: false,
+					green: false,
+					blue: false,
+				},
+				penalties: [],
+			},
+			hasSubmittedChoice: false,
+		},
+	},
+	dice: {
+		white1: 1,
+		white2: 2,
+		red: 3,
+		yellow: 4,
+		green: 5,
+		blue: 6,
+	},
+	activePlayer: "testUser1",
+	hasRolled: true,
+}
+
+export const user1HasSubmittedState = {
+	players: {
+		testUser1: {
+			gameCard: {
+				rows: {
+					red: [],
+					yellow: [],
+					green: [],
+					blue: [],
+				},
+				isLocked: {
+					red: false,
+					yellow: false,
+					green: false,
+					blue: false,
+				},
+				penalties: [],
+			},
+			hasSubmittedChoice: true,
+		},
+		testUser2: {
+			gameCard: {
+				rows: {
+					red: [],
+					yellow: [],
+					green: [],
+					blue: [],
+				},
+				isLocked: {
+					red: false,
+					yellow: false,
+					green: false,
+					blue: false,
+				},
+				penalties: [],
+			},
+			hasSubmittedChoice: false,
+		},
+		testUser3: {
+			gameCard: {
+				rows: {
+					red: [],
+					yellow: [],
+					green: [],
+					blue: [],
+				},
+				isLocked: {
+					red: false,
+					yellow: false,
+					green: false,
+					blue: false,
+				},
+				penalties: [],
+			},
+			hasSubmittedChoice: false,
+		},
+	},
+	dice: {
+		white1: 1,
+		white2: 2,
+		red: 3,
+		yellow: 4,
+		green: 5,
+		blue: 6,
+	},
+	activePlayer: "testUser1",
+	hasRolled: true,
+}

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -223,7 +223,13 @@ export default class QwixxLogic {
   // TODO: 
   // Do we need a check to see if active player has made a move before ending a turn?
   // If we do, do we need to process penalty?
+  // Maybe add a check to see if the dice has already been rolled to stop a player from ending a turn
+  // before rolling a dice
   public endTurn(playerName: string) {
+    if (!this.hasRolled) {
+      return { success: false, errorMessage: "Dice hasn't been rolled yet." }
+    }
+
     const player = this.playerExistsInLobby(playerName);
 
     if (!player) {
@@ -231,9 +237,11 @@ export default class QwixxLogic {
     }
 
     if (player.hasSubmittedChoice) {
-      throw new Error("Player already finished their turn.");
+      return { success: false, errorMessage: "Player has already ended their turn." }
     }
 
+    // ISSUE: 
+    // These two snippets do the same thing. Is there something that needs to be handled differently?
     if (player !== this.activePlayer) {
       player.markSubmitted();
     }
@@ -244,7 +252,7 @@ export default class QwixxLogic {
 
     this.processPlayersSubmission();
 
-    return this.serialize();
+    return { success: true, data: this.serialize() };
   }
 
   public processPenalty(playerName: string) {

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -220,7 +220,7 @@ export default class QwixxLogic {
       isValid: true,
     };
   }
-  // TODO: 
+
   public endTurn(playerName: string) {
     if (!this.hasRolled) {
       return { success: false, errorMessage: "Dice hasn't been rolled yet." }

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -221,10 +221,6 @@ export default class QwixxLogic {
     };
   }
   // TODO: 
-  // Do we need a check to see if active player has made a move before ending a turn?
-  // If we do, do we need to process penalty?
-  // Maybe add a check to see if the dice has already been rolled to stop a player from ending a turn
-  // before rolling a dice
   public endTurn(playerName: string) {
     if (!this.hasRolled) {
       return { success: false, errorMessage: "Dice hasn't been rolled yet." }
@@ -240,13 +236,14 @@ export default class QwixxLogic {
       return { success: false, errorMessage: "Player has already ended their turn." }
     }
 
-    // ISSUE: 
-    // These two snippets do the same thing. Is there something that needs to be handled differently?
     if (player !== this.activePlayer) {
       player.markSubmitted();
     }
 
     if (player === this.activePlayer) {
+      if (player.submissionCount === 0) {
+        player.gameCard.addPenalty()
+      }
       player.markSubmitted();
     }
 
@@ -263,7 +260,6 @@ export default class QwixxLogic {
 
     player.gameCard.addPenalty()
     player.markSubmitted();
-
     this.processPlayersSubmission();
 
     return this.serialize();

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -220,7 +220,9 @@ export default class QwixxLogic {
       isValid: true,
     };
   }
-
+  // TODO: 
+  // Do we need a check to see if active player has made a move before ending a turn?
+  // If we do, do we need to process penalty?
   public endTurn(playerName: string) {
     const player = this.playerExistsInLobby(playerName);
 

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -262,5 +262,32 @@ export default function initializeSocketHandler(io: Server) {
         }
       }
     });
+
+    socket.on("end_turn", ({ lobbyId, userId }) => {
+      if (!lobbyId || !userId) {
+        console.error("Missing data");
+        socket.emit("error_occured", {
+          message: "Missing data for marking penalties",
+        });
+        return;
+      }
+
+      const gameState = lobbiesMap[lobbyId].gameLogic;
+
+      if (!gameState) {
+        socket.emit("error_occured", { message: "Lobby or game not found" });
+        return;
+      }
+
+      try {
+        const res = gameState.endTurn(userId)
+        socket.emit("turn_ended", { gameState: res })
+      } catch (err) {
+        if (err instanceof Error) {
+          socket.emit("error_occured", { message: err.message })
+        }
+      }
+
+    })
   });
 }

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -283,11 +283,12 @@ export default function initializeSocketHandler(io: Server) {
         const res = gameState.endTurn(userId)
 
         if (!res.success) {
+          console.log(res.errorMessage)
           socket.emit("error_occured", { message: res.errorMessage })
         }
-
         if (res.success) {
-          socket.emit("turn_ended", { gameState: res.data })
+          console.log(res.data)
+          io.to(lobbyId).emit("turn_ended", { gameState: res.data })
         }
       } catch (err) {
         if (err instanceof Error) {

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -281,7 +281,14 @@ export default function initializeSocketHandler(io: Server) {
 
       try {
         const res = gameState.endTurn(userId)
-        socket.emit("turn_ended", { gameState: res })
+
+        if (!res.success) {
+          socket.emit("error_occured", { message: res.errorMessage })
+        }
+
+        if (res.success) {
+          socket.emit("turn_ended", { gameState: res.data })
+        }
       } catch (err) {
         if (err instanceof Error) {
           socket.emit("error_occured", { message: err.message })

--- a/server/src/tests/models/QwixxBaseGameCard.test.ts
+++ b/server/src/tests/models/QwixxBaseGameCard.test.ts
@@ -81,4 +81,10 @@ describe("Base Game Card test", () => {
     const res = testGameCard.hasAvailableMoves(obj);
     expect(res).toBeTruthy();
   });
+
+  it("can add penalty to game card", () => {
+    testGameCard.addPenalty()
+    const penalties = testGameCard.penalties
+    expect(penalties).toEqual([1,])
+  })
 });

--- a/server/src/tests/models/QwixxBaseGameCard.test.ts
+++ b/server/src/tests/models/QwixxBaseGameCard.test.ts
@@ -3,7 +3,7 @@ import qwixxBaseGameCard from "../../models/QwixxBaseGameCard";
 
 let testGameCard: qwixxBaseGameCard;
 
-describe("gameboard temp test", () => {
+describe("Base Game Card test", () => {
   beforeEach(() => {
     testGameCard = new qwixxBaseGameCard();
   });
@@ -30,12 +30,45 @@ describe("gameboard temp test", () => {
     expect(rows).toEqual(expected);
   });
 
-  test("mark numbers already on board", () => {
+  test("Can't mark numbers already on board", () => {
     testGameCard.markNumbers(rowColour.Red, 5);
-    testGameCard.markNumbers(rowColour.Red, 5);
+    const result = testGameCard.markNumbers(rowColour.Red, 5);
+    expect(result.success).toBeFalsy()
+    if (!result.success) {
+      expect(result.errorMessage).toBe("Number 5 is already marked in red row.")
+    }
+
     const rows = testGameCard.MarkedNumbers;
     expect(rows).toEqual({ red: [5], yellow: [], green: [], blue: [] });
   });
+
+  test("Can't mark a number that is lower than previous number on red row", () => {
+    testGameCard.markNumbers(rowColour.Red, 5);
+    const result = testGameCard.markNumbers(rowColour.Red, 4);
+    expect(result.success).toBeFalsy()
+    if (!result.success) {
+      expect(result.errorMessage).toBe(
+        "Invalid move. Number is not higher/lower than previous marked number"
+      )
+    }
+
+    const rows = testGameCard.MarkedNumbers;
+    expect(rows).toEqual({ red: [5], yellow: [], green: [], blue: [] });
+  })
+
+  test("Can't mark a number that is higher than previous number on blue row", () => {
+    testGameCard.markNumbers(rowColour.Blue, 5);
+    const result = testGameCard.markNumbers(rowColour.Blue, 6);
+    expect(result.success).toBeFalsy()
+    if (!result.success) {
+      expect(result.errorMessage).toBe(
+        "Invalid move. Number is not higher/lower than previous marked number"
+      )
+    }
+
+    const rows = testGameCard.MarkedNumbers;
+    expect(rows).toEqual({ red: [], yellow: [], green: [], blue: [5] });
+  })
 
   test("return true if there are available moves based on current gamecard", () => {
     const obj = {

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -44,12 +44,15 @@ describe("Qwixx Logic integration tests:", () => {
 
   describe("Game logic tests", () => {
     test("making a move before rolling dice throws an error", () => {
-      expect(() => testGame.makeMove("test-player1", "red", 2)).toThrow(
-        "Dice hasn't been rolled yet."
-      );
+      const res = testGame.makeMove("test-player1", "red", 2)
+
+      expect(res.success).toBeFalsy()
+      if (!res.success) {
+        expect(res.error).toBe("Dice hasn't been rolled yet.")
+      }
     });
 
-    it.only("should make a move and return the correct result", () => {
+    it("should make a move and return the correct result", () => {
       const result = testGame.rollDice();
       const whiteDiceSum = result.diceValues.white1 + result.diceValues.white2;
 
@@ -127,12 +130,22 @@ describe("Qwixx Logic integration tests:", () => {
     });
 
     it("should roll all dice and return a value", () => {
-      const diceValues = testGame.rollDice();
-      Object.values(diceValues).forEach((value) => {
+      const result = testGame.rollDice();
+      Object.values(result.diceValues).forEach((value) => {
         expect(value).toBeGreaterThanOrEqual(1);
         expect(value).toBeLessThanOrEqual(6);
       });
     });
+
+    it("should roll all dice and return whether active player has available moves", () => {
+      const result = testGame.rollDice();
+      expect(result.hasAvailableMoves).toBeTruthy()
+    })
+
+    it("should roll all the dice and return the value of hasRolled as true", () => {
+      const result = testGame.rollDice();
+      expect(result.hasRolled).toBeTruthy()
+    })
   });
 
   describe("active player tests", () => {
@@ -149,10 +162,11 @@ describe("Qwixx Logic integration tests:", () => {
       testGame.rollDice();
       testGame.makeMove("test-player1", "red", 5);
       testGame.makeMove("test-player1", "red", 7);
-
-      expect(() => {
-        testGame.makeMove("test-player1", "yellow", 7);
-      }).toThrow("Player already finished their turn");
+      const result = testGame.makeMove("test-player1", "yellow", 7)
+      expect(result.success).toBeFalsy()
+      if (!result.success) {
+        expect(result.error)
+      }
     });
 
     test("current player's hasSubmittedChoice is updated after submitting 2 moves", () => {
@@ -177,9 +191,11 @@ describe("Qwixx Logic integration tests:", () => {
 
       testGame.rollDice();
 
-      expect(() => {
-        testGame.makeMove("test-player1", "red", 9);
-      }).toThrow("Number selected doesn't equal to sum of white dice.");
+      const result = testGame.makeMove("test-player1", "red", 9)
+      expect(result.success).toBeFalsy()
+      if (!result.success) {
+        expect(result.error).toBe("Number selected doesn't equal to sum of white dice.")
+      }
     });
 
     test.each([
@@ -203,31 +219,32 @@ describe("Qwixx Logic integration tests:", () => {
           });
 
         testGame.rollDice();
-        expect(() => {
-          testGame.makeMove("test-player1", row, num);
-        }).toThrow(
-          "Number selected doesn't equal to sum of white die and coloured die."
-        );
+
+        const result = testGame.makeMove("test-player1", row, num);
+        expect(result.success).toBeFalsy()
+        if (!result.success) {
+          expect(result.error).toBe("Number selected doesn't equal to sum of white die and coloured die.")
+        }
       }
     );
 
-    //test("active-player can mark a number that equals the sum of a white and a coloured die", () => {
-    //  const diceResults = testGame.rollDice();
-    //  const firstNumber = diceResults.white1 + diceResults.white2;
-    //  testGame.makeMove("test-player1", "blue", firstNumber);
+    test("active-player can mark a number that equals the sum of a white and a coloured die", () => {
+      const diceResults = testGame.rollDice();
+      const firstNumber = diceResults.diceValues.white1 + diceResults.diceValues.white2;
+      testGame.makeMove("test-player1", "blue", firstNumber);
 
-    //  const secondNumber = diceResults.white1 + diceResults.red;
+      const secondNumber = diceResults.diceValues.white1 + diceResults.diceValues.red;
 
-    //  const validNumbers = mockDice.validColouredNumbers;
+      const validNumbers = mockDice.validColouredNumbers;
 
-    //  expect(validNumbers["red"]?.includes(secondNumber)).toBeTruthy;
+      expect(validNumbers["red"]?.includes(secondNumber)).toBeTruthy;
 
-    //  expect(() =>
-    //    testGame.makeMove("test-player1", "red", secondNumber)
-    //  ).not.toThrow(
-    //    "Number selected doesn't equal to sum of white die and coloured die."
-    //  );
-    //});
+      expect(() =>
+        testGame.makeMove("test-player1", "red", secondNumber)
+      ).not.toThrow(
+        "Number selected doesn't equal to sum of white die and coloured die."
+      );
+    });
 
     test("current player can end their turn without submitting a move", () => {
       testGame.rollDice();
@@ -247,9 +264,11 @@ describe("Qwixx Logic integration tests:", () => {
       testGame.rollDice();
       testGame.makeMove("test-player2", "red", 5);
 
-      expect(() => {
-        testGame.makeMove("test-player2", "red", 7);
-      }).toThrow("Player already finished their turn");
+      const result = testGame.makeMove("test-player2", "red", 7);
+      expect(result.success).toBeFalsy()
+      if (!result.success) {
+        expect(result.error).toBe("Player already finished their turn.")
+      }
     });
 
     test("non-current player's hasSubmittedChoice is updated after submitting 1 move", () => {

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -284,4 +284,50 @@ describe("Qwixx Logic integration tests:", () => {
       expect(mockPlayer2.hasSubmittedChoice).toBeTruthy();
     });
   });
+
+  describe("end turn tests", () => {
+    test("active player can end their turn", () => {
+      testGame.rollDice()
+      const result = testGame.endTurn("test-player1")
+      expect(result.success).toBeTruthy()
+      if (result.success) {
+        const player1State = result.data?.players["test-player1"]
+        expect(player1State?.hasSubmittedChoice).toBeTruthy()
+      }
+    })
+
+    it("doesn't add a penalty to the active player when they marked a number and end their turn", () => {
+      testGame.rollDice()
+      const diceResult = testGame.rollDice();
+      const whiteDiceSum = diceResult.diceValues.white1 + diceResult.diceValues.white2;
+      testGame.makeMove("test-player1", "red", whiteDiceSum);
+
+      const result = testGame.endTurn("test-player1")
+      expect(result.success).toBeTruthy()
+      if (result.success) {
+        const player1State = result.data?.players["test-player1"]
+        expect(player1State?.gameCard.penalties).not.toEqual([1,])
+      }
+    })
+
+    it("adds a penalty to the active player if they end turn without marking a number", () => {
+      testGame.rollDice()
+      const result = testGame.endTurn("test-player1")
+      expect(result.success).toBeTruthy()
+      if (result.success) {
+        const player1State = result.data?.players["test-player1"]
+        expect(player1State?.gameCard.penalties).toEqual([1,])
+      }
+    })
+
+    it("returns an error if player has already end their turn", () => {
+      testGame.rollDice()
+      testGame.endTurn("test-player1")
+      const result = testGame.endTurn("test-player1")
+      expect(result.success).toBeFalsy()
+      if (!result.success) {
+        expect(result.errorMessage).toBe("Player has already ended their turn.")
+      }
+    })
+  })
 });

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -82,19 +82,27 @@ describe("Qwixx Logic integration tests:", () => {
     });
 
     test("when all players have submitted a move, it should go to the next turn by making the next player the active player", () => {
-      const result = testGame.rollDice();
+      testGame.rollDice();
       const initialGameState = testGame.serialize();
-      console.log(result);
       expect(initialGameState.activePlayer).toBe("test-player1");
 
-      //  const firstMoveState = testGame.makeMove("test-player1", "red", 5);
-      //  expect(firstMoveState.activePlayer).toBe("test-player1");
+      const firstMoveState = testGame.makeMove("test-player1", "red", 5);
+      expect(firstMoveState.success).toBeTruthy()
+      if (firstMoveState.success) {
+        expect(firstMoveState.data.activePlayer).toBe("test-player1");
+      }
 
-      //  const secondMoveState = testGame.makeMove("test-player1", "red", 7);
-      //  expect(secondMoveState.activePlayer).toBe("test-player1");
+      const secondMoveState = testGame.makeMove("test-player1", "red", 7);
+      expect(secondMoveState.success).toBeTruthy()
+      if (secondMoveState.success) {
+        expect(secondMoveState.data.activePlayer).toBe("test-player1");
+      }
 
-      //  const finalMoveState = testGame.makeMove("test-player2", "blue", 5);
-      //  expect(finalMoveState.activePlayer).toBe("test-player2");
+      const finalMoveState = testGame.makeMove("test-player2", "blue", 5);
+      expect(finalMoveState).toBeTruthy()
+      if (finalMoveState.success) {
+        expect(finalMoveState.data.activePlayer).toBe("test-player2");
+      }
     });
 
     test("when the game goes to the next turn, all players' submission state is reset", () => {
@@ -293,6 +301,17 @@ describe("Qwixx Logic integration tests:", () => {
       if (result.success) {
         const player1State = result.data?.players["test-player1"]
         expect(player1State?.hasSubmittedChoice).toBeTruthy()
+      }
+    })
+
+    test("non-active player can end their turn without penalty", () => {
+      testGame.rollDice()
+      const result = testGame.endTurn("test-player2")
+      expect(result.success).toBeTruthy()
+      if (result.success) {
+        const player2State = result.data?.players["test-player2"]
+        expect(player2State?.hasSubmittedChoice).toBeTruthy()
+        expect(player2State?.gameCard.penalties).not.toEqual([1,])
       }
     })
 

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -263,5 +263,29 @@ describe("Qwixx Logic tests", () => {
 
       expect(res.data?.players.player1.hasSubmittedChoice).toBeTruthy()
     });
+
+    test.only("Can't end a turn if a dice hasn't been rolled", () => {
+      const testGame = new QwixxLogic(playersArrayMock, fakeDice)
+      const res = testGame.endTurn("player1");
+
+      expect(res.success).toBeFalsy()
+      expect(res.errorMessage).toBe("Dice hasn't been rolled yet.")
+    })
+
+    test.only("should throw an error if player not found", () => {
+      const testGame = new QwixxLogic(playersArrayMock, fakeDice)
+      testGame.rollDice()
+      expect(() => testGame.endTurn("player3")).toThrow("Player not found.")
+    })
+
+    test.only("Player can't end a turn if they've already finished their turn", () => {
+      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+      testGame.rollDice()
+      testGame.endTurn("player1");
+      const res = testGame.endTurn("player1");
+
+      expect(res.success).toBeFalsy()
+      expect(res.errorMessage).toBe("Player has already ended their turn.")
+    })
   })
 });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -68,7 +68,7 @@ describe("Qwixx Logic tests", () => {
     it("should call the markNumber method with correct args", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       testGame.rollDice();
-      console.log(testGame.makeMove("player1", "red", 10));
+      testGame.makeMove("player1", "red", 10);
 
       expect(player1Mock.markNumber).toHaveBeenCalledWith("red", 10);
       expect(player1Mock.markNumber).toHaveBeenCalledTimes(1);
@@ -256,15 +256,15 @@ describe("Qwixx Logic tests", () => {
   });
 
   describe("endTurn method tests", () => {
-    test.only("A player can end their turn", () => {
+    test("A player can end their turn", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       testGame.rollDice()
       const res = testGame.endTurn("player1");
-
+      console.log(res)
       expect(res.data?.players.player1.hasSubmittedChoice).toBeTruthy()
     });
 
-    test.only("Can't end a turn if a dice hasn't been rolled", () => {
+    test("Can't end a turn if a dice hasn't been rolled", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice)
       const res = testGame.endTurn("player1");
 
@@ -272,13 +272,13 @@ describe("Qwixx Logic tests", () => {
       expect(res.errorMessage).toBe("Dice hasn't been rolled yet.")
     })
 
-    test.only("should throw an error if player not found", () => {
+    test("should throw an error if player not found", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice)
       testGame.rollDice()
       expect(() => testGame.endTurn("player3")).toThrow("Player not found.")
     })
 
-    test.only("Player can't end a turn if they've already finished their turn", () => {
+    test("Player can't end a turn if they've already finished their turn", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       testGame.rollDice()
       testGame.endTurn("player1");
@@ -286,6 +286,15 @@ describe("Qwixx Logic tests", () => {
 
       expect(res.success).toBeFalsy()
       expect(res.errorMessage).toBe("Player has already ended their turn.")
+    })
+
+    test.skip("Active player receives a penalty if they end their turn without marking a number", () => {
+      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+      testGame.rollDice()
+      const res = testGame.endTurn("player1");
+
+      //      expect(res.data?.players.player1.gameCard.penalties).toEqual([])
+      expect(gameCardMock1.addPenalty).toHaveBeenCalledTimes(1)
     })
   })
 });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -184,12 +184,6 @@ describe("Qwixx Logic tests", () => {
       expect(() => {
         testGame.makeMove("player1", "red", 10);
       }).toThrow("Number must be above the last marked number");
-
-      // TODO: Explain why this isn't necessary
-
-      //      jest
-      //        .spyOn(gameCardMock1, "getHighestMarkedNumber")
-      //        .mockImplementation(originalImplementation);
     });
 
     // TODO: I think this test is no longer necessary as it can be tested inside of game card
@@ -253,34 +247,21 @@ describe("Qwixx Logic tests", () => {
     it("should add a penalty to the players gamecard", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
 
-      // TODO: explain why this test isn't applicable in this unit test
-
-      //      const serializedData = {
-      //        gamecard: {
-      //          rows: {
-      //            red: [],
-      //            yellow: [],
-      //            green: [],
-      //            blue: [],
-      //          },
-      //          isLocked: {
-      //            red: false,
-      //            yellow: false,
-      //            green: false,
-      //            blue: false,
-      //          },
-      //          penalties: [1],
-      //        },
-      //        hasSubmittedChoice: false,
-      //      };
-
-      // jest.spyOn(player1Mock, "serialize").mockReturnValue(serializedData);
 
       const addPenaltySpy = jest.spyOn(player1Mock.gameCard, "addPenalty");
       testGame.processPenalty("player1");
 
       expect(addPenaltySpy).toHaveBeenCalled();
-      //expect(player1Mock.serialize()).toEqual(serializedData);
     });
   });
+
+  describe("endTurn method tests", () => {
+    test.only("A player can end their turn", () => {
+      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+      testGame.rollDice()
+      const res = testGame.endTurn("player1");
+
+      expect(res.data?.players.player1.hasSubmittedChoice).toBeTruthy()
+    });
+  })
 });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -159,60 +159,6 @@ describe("Qwixx Logic tests", () => {
         );
       }
     );
-
-    test.skip("active-player marking a number that equals the sum of a white dice but lower than highest marked red row will throw an error", () => {
-
-      // TODO: Explain why this is no longer applicable and how to test it.
-      // We just mock the return value of markNumber without having to write complicated mock implementations.
-      // We just test the behaviour of what happens inside of Qwixx Logic by reducing coupling.
-
-      //      const originalImplementation = gameCardMock1.getHighestMarkedNumber;
-      //
-      //      jest
-      //        .spyOn(gameCardMock1, "getHighestMarkedNumber")
-      //        .mockImplementation((row) => {
-      //          if (row === "red") return 11;
-      //          if (row === "yellow") return 8;
-      //          if (row === "green") return 8;
-      //          if (row === "blue") return 8;
-      //          return 2;
-      //        });
-
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      testGame.rollDice();
-
-      expect(() => {
-        testGame.makeMove("player1", "red", 10);
-      }).toThrow("Number must be above the last marked number");
-    });
-
-    // TODO: I think this test is no longer necessary as it can be tested inside of game card
-    test.skip("should throw error when trying to mark blue 10, if gamecard has no valid moves", () => {
-      jest
-        .spyOn(gameCardMock1, "getHighestMarkedNumber")
-        .mockImplementation((row) => {
-          if (row === "red" || row === "yellow") return 11;
-          return 10;
-        });
-
-      jest
-        .spyOn(gameCardMock1, "getLowestMarkedNumber")
-        .mockImplementation((row) => {
-          if (row === "green" || row === "blue") return 6;
-          return 4;
-        });
-
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      testGame.rollDice();
-      //const isMoveAvailable = testGame.validMoveAvailable();
-
-      expect(() => {
-        testGame.makeMove("player1", "blue", 10);
-      }).toThrow("Number must be below the last marked number");
-
-      //expect(isMoveAvailable["player1"]).toBe(false);
-      //expect(isMoveAvailable["player2"]).toBe(true);
-    });
   })
 
   describe("rollDice method tests", () => {
@@ -256,14 +202,6 @@ describe("Qwixx Logic tests", () => {
   });
 
   describe("endTurn method tests", () => {
-    test("A player can end their turn", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      testGame.rollDice()
-      const res = testGame.endTurn("player1");
-      console.log(res)
-      expect(res.data?.players.player1.hasSubmittedChoice).toBeTruthy()
-    });
-
     test("Can't end a turn if a dice hasn't been rolled", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice)
       const res = testGame.endTurn("player1");
@@ -276,25 +214,6 @@ describe("Qwixx Logic tests", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice)
       testGame.rollDice()
       expect(() => testGame.endTurn("player3")).toThrow("Player not found.")
-    })
-
-    test("Player can't end a turn if they've already finished their turn", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      testGame.rollDice()
-      testGame.endTurn("player1");
-      const res = testGame.endTurn("player1");
-
-      expect(res.success).toBeFalsy()
-      expect(res.errorMessage).toBe("Player has already ended their turn.")
-    })
-
-    test.skip("Active player receives a penalty if they end their turn without marking a number", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      testGame.rollDice()
-      const res = testGame.endTurn("player1");
-
-      //      expect(res.data?.players.player1.gameCard.penalties).toEqual([])
-      expect(gameCardMock1.addPenalty).toHaveBeenCalledTimes(1)
     })
   })
 });


### PR DESCRIPTION
## Description
During a player's turn, both the active player and the non-active player can choose to end their turn without making a move.

- Active player receives a penalty if they end their turn without marking a number.
- See issue https://github.com/kashida2021/qwixx_game/issues/51

## How
- Updated the endTurn method.
- Added an event listener in socketHandler for the end-turn event.
- Added event listener to client-side App.tsx
- Added a button to the game page to send the end-turn event.
- Made a fixtures directory to hold different test game states for GamePage.
- Removed the test state from GamePage test.
- Updated tests in QwixxBaseGameCard and QwixxLogic.

## Why
- endTurn method needed to reflect the rule for receiving a penalty when the active player made no moves.
- The end turn button was added so the event could be triggered.
- Moved test game states to fixtures because it was cluttering up test file.
- I found many tests in QwixxLogic were skipped, so I updated them to ensure they reflect the project's current state.
- I added missing tests to QwixxBaseGameCard.