### PR TITLE
49/feature/game end logic

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,6 +19,8 @@ function App() {
   const [gameState, setGameState] = useState<QwixxLogic | null>(null);
   const [gamePath, setGamePath] = useState("");
   const [availableMoves, setAvailableMoves] = useState<boolean>(false);
+  const [isGameEnd, setIsGameEnd] = useState<boolean>(false);
+  const [gameSummary, setGameSummary] = useState(null)
 
   //Need to consier if this is overkill for our app as it's only being used in one place.
   //  const handleInputChange =
@@ -123,7 +125,7 @@ function App() {
       console.log("penalty data", data.responseData);
     }
 
-    const handlePassMove = ( data: {gameState: QwixxLogic} ) => {
+    const handlePassMove = (data: { gameState: QwixxLogic }) => {
       setGameState(data.gameState);
       console.log(data.gameState);
     }
@@ -131,6 +133,11 @@ function App() {
     const onRowLocked = (data: { gameState: QwixxLogic }) => {
       setGameState(data.gameState)
       console.log("Data after locking a row", data)
+    }
+
+    const onGameEnd = (data: { gameState: any }) => {
+      setIsGameEnd(true)
+      setGameSummary(data.gameState)
     }
 
     socket.on("connect", onConnect);
@@ -147,6 +154,7 @@ function App() {
     socket.on("row_locked", onRowLocked)
     socket.on("turn_ended", onTurnEnded);
     socket.on("passMoveProcessed", handlePassMove);
+    socket.on("game_ended", onGameEnd);
 
     return () => {
       socket.off("connect");
@@ -163,6 +171,7 @@ function App() {
       socket.off("turn_ended");
       socket.off("passMoveProcessed");
       socket.off("row_locked")
+      socket.off("game_ended")
     };
   }, []);
 
@@ -208,6 +217,8 @@ function App() {
                 members={members}
                 gameState={gameState}
                 availableMoves={availableMoves}
+                isGameEnd={isGameEnd}
+                gameSummary={gameSummary}
               // setGameBoardState={setGameBoardState}
               />
             ) : (

--- a/client/src/pages/GamePage/GamePage.tsx
+++ b/client/src/pages/GamePage/GamePage.tsx
@@ -23,6 +23,8 @@ interface IGameProps {
   members: string[];
   gameState: QwixxLogic;
   availableMoves: boolean;
+  isGameEnd: boolean;
+  gameSummary: any;
   // setGameBoardState: Dispatch<SetStateAction<GameBoard | null>>;
 }
 
@@ -33,12 +35,14 @@ export const Game: React.FC<IGameProps> = ({
   gameState,
   socket,
   availableMoves,
+  isGameEnd,
+  gameSummary,
 }) => {
   const [playerChoice, setPlayerChoice] = useState<{
     row: string;
     num: number;
   } | null>(null);
-  
+
   const [submissionCount, setSubmissionCount] = useState<number>(0);
 
   useEffect(() => {
@@ -79,7 +83,7 @@ export const Game: React.FC<IGameProps> = ({
 
   const handleNumberSelection = () => {
     socket.emit("mark_numbers", { lobbyId, userId, playerChoice }, (isSuccessful: boolean) => {
-      if(isSuccessful){
+      if (isSuccessful) {
         setSubmissionCount((prev) => prev + 1);
       } else {
         console.log("move not successful");
@@ -93,7 +97,7 @@ export const Game: React.FC<IGameProps> = ({
   }
 
   const handlePassMove = () => {
-    socket.emit("pass_move", {lobbyId, userId});
+    socket.emit("pass_move", { lobbyId, userId });
     setSubmissionCount((prev) => prev + 1);
   }
 
@@ -155,11 +159,14 @@ export const Game: React.FC<IGameProps> = ({
             (<button onClick={handleNumberSelection} disabled={hasSubmitted}>Confirm</button>)
           }
           {/* For ending a turn even if there are available moves */}
-          <button className="" onClick={handleEndTurn} disabled={hasSubmitted || !hasRolled}>End Turn</button>          
+          <button className="" onClick={handleEndTurn} disabled={hasSubmitted || !hasRolled}>End Turn</button>
           {/* Possibly need to update structure of data sent back from backend to include submission count to disable button on 2nd choice rather than hasSubmitted */}
-          <button className="" onClick={handlePassMove} disabled={hasSubmitted || !hasRolled || activePlayer !== userId || submissionCount > 0  }>Pass Move</button>
-
+          <button className="" onClick={handlePassMove} disabled={hasSubmitted || !hasRolled || activePlayer !== userId || submissionCount > 0}>Pass Move</button>
         </div>
+      </div>
+      {/* Temporarily putting this here so we can see who is the winner*/}
+      <div className="game-page__game-summary">
+        {isGameEnd ? (<p> Winner is {gameSummary.winners}</p>) : (<p></p>)}
       </div>
     </div>
   );

--- a/server/src/models/DiceClass.ts
+++ b/server/src/models/DiceClass.ts
@@ -1,11 +1,12 @@
 import SixSidedDie from "./SixSidedDieClass";
 import { DiceColour } from "../enums/DiceColours";
 import { rowColour } from "../enums/rowColours";
+import IDice from "./IDice";
 
 type TDice = Record<DiceColour, SixSidedDie>
 export type TDiceValues = Record<DiceColour, number>
 
-export default class Dice {
+export default class Dice implements IDice {
   private _dice: TDice;
   private _diceValues: TDiceValues;
 
@@ -29,20 +30,6 @@ export default class Dice {
     };
   }
 
-  public rollAllDice(): TDiceValues {
-    let diceColours = Object.keys(this._dice) as DiceColour[];
-    diceColours.forEach((colour) => {
-      const dieColour = colour as DiceColour;
-      if (this._dice[dieColour].active === false) {
-        this.diceValues[dieColour] = 0;
-      } else {
-        // this._dice[dieColour].rollDie();
-        // this._diceValues[dieColour] = this._dice[dieColour].value;
-        this.diceValues[dieColour] = this._dice[dieColour].rollDie();
-      }
-    });
-    return this.diceValues;
-  }
 
   get diceValues(): TDiceValues {
     return this._diceValues;
@@ -71,6 +58,21 @@ export default class Dice {
     }
 
     return result;
+  }
+
+  public rollAllDice(): TDiceValues {
+    let diceColours = Object.keys(this._dice) as DiceColour[];
+    diceColours.forEach((colour) => {
+      const dieColour = colour as DiceColour;
+      if (this._dice[dieColour].active === false) {
+        this.diceValues[dieColour] = 0;
+      } else {
+        // this._dice[dieColour].rollDie();
+        // this._diceValues[dieColour] = this._dice[dieColour].value;
+        this.diceValues[dieColour] = this._dice[dieColour].rollDie();
+      }
+    });
+    return this.diceValues;
   }
 
   public disableDie(colour: DiceColour): void {

--- a/server/src/models/DiceClass.ts
+++ b/server/src/models/DiceClass.ts
@@ -32,19 +32,12 @@ export default class Dice implements IDice {
     return this.diceValues.white1 + this.diceValues.white2;
   }
 
-  // get validColouredNumbers(): number[] {
-  //   const whiteValues = [this._diceValues.white1, this._diceValues.white2];
-  //   const colouredValues = [this._diceValues.red, this._diceValues.yellow, this._diceValues.green, this._diceValues.blue];
-  //   return whiteValues.flatMap(white => colouredValues.filter(value => value > 0).map(value => value + white));
-  // }
-
   /**
    * @description Returns all possible number combinations for white and coloured dice in accordance to game rules
    * @returns An object mapping dice colours to an array of white die + the respective coloured die's value
    */
   public get validColouredNumbers() {
     const { white1, white2, ...colouredValues } = this.diceValues;
-    //const result: { [key in rowColour]?: number[] } = {};
     const result: Partial<Record<rowColour, number[]>> = {};
 
     for (const [colour, value] of Object.entries(colouredValues)) {
@@ -61,13 +54,7 @@ export default class Dice implements IDice {
     let diceColours = Object.keys(this._dice) as DiceColour[];
     diceColours.forEach((colour) => {
       const dieColour = colour as DiceColour;
-      if (this._dice[dieColour].active === false) {
-        this.diceValues[dieColour] = 0;
-      } else {
-        // this._dice[dieColour].rollDie();
-        // this._diceValues[dieColour] = this._dice[dieColour].value;
-        this.diceValues[dieColour] = this._dice[dieColour].rollDie();
-      }
+      this.diceValues[dieColour] = this._dice[dieColour].rollDie();
     });
     return this.diceValues;
   }

--- a/server/src/models/DiceClass.ts
+++ b/server/src/models/DiceClass.ts
@@ -2,23 +2,17 @@ import SixSidedDie from "./SixSidedDieClass";
 import { DiceColour } from "../enums/DiceColours";
 import { rowColour } from "../enums/rowColours";
 import IDice from "./IDice";
+import IDie from "./IDie";
 
-type TDice = Record<DiceColour, SixSidedDie>
-export type TDiceValues = Record<DiceColour, number>
+type TDice = Record<DiceColour, IDie>;
+export type TDiceValues = Record<DiceColour, number>;
 
 export default class Dice implements IDice {
   private _dice: TDice;
   private _diceValues: TDiceValues;
 
-  constructor(die: typeof SixSidedDie) {
-    this._dice = {
-      [DiceColour.White1]: new die(),
-      [DiceColour.White2]: new die(),
-      [DiceColour.Red]: new die(),
-      [DiceColour.Yellow]: new die(),
-      [DiceColour.Green]: new die(),
-      [DiceColour.Blue]: new die(),
-    };
+  constructor(dice: Record<DiceColour, IDie>) {
+    this._dice = dice;
 
     this._diceValues = {
       [DiceColour.White1]: 1,
@@ -30,13 +24,12 @@ export default class Dice implements IDice {
     };
   }
 
-
   get diceValues(): TDiceValues {
     return this._diceValues;
   }
 
   public get whiteDiceSum() {
-    return this.diceValues.white1 + this.diceValues.white2
+    return this.diceValues.white1 + this.diceValues.white2;
   }
 
   // get validColouredNumbers(): number[] {
@@ -47,8 +40,8 @@ export default class Dice implements IDice {
 
   /**
    * @description Returns all possible number combinations for white and coloured dice in accordance to game rules
-   * @returns An object mapping dice colours to an array of white die + the respective coloured die's value 
-  */
+   * @returns An object mapping dice colours to an array of white die + the respective coloured die's value
+   */
   public get validColouredNumbers() {
     const { white1, white2, ...colouredValues } = this.diceValues;
     //const result: { [key in rowColour]?: number[] } = {};

--- a/server/src/models/DiceClass.ts
+++ b/server/src/models/DiceClass.ts
@@ -45,6 +45,10 @@ export default class Dice implements IDice {
   //   return whiteValues.flatMap(white => colouredValues.filter(value => value > 0).map(value => value + white));
   // }
 
+  /**
+   * @description Returns all possible number combinations for white and coloured dice in accordance to game rules
+   * @returns An object mapping dice colours to an array of white die + the respective coloured die's value 
+  */
   public get validColouredNumbers() {
     const { white1, white2, ...colouredValues } = this.diceValues;
     //const result: { [key in rowColour]?: number[] } = {};

--- a/server/src/models/IDice.ts
+++ b/server/src/models/IDice.ts
@@ -1,0 +1,15 @@
+import { DiceColour } from "../enums/DiceColours";
+import { rowColour } from "../enums/rowColours";
+import { TDiceValues } from "./DiceClass";
+
+export default interface IDice {
+  // Getters for public fields
+  diceValues: TDiceValues;
+  whiteDiceSum: number;
+  validColouredNumbers: Partial<Record<rowColour, number[]>>;
+
+  // Public methods
+  rollAllDice(): TDiceValues;
+  disableDie(colour: DiceColour): void;
+  serialize(): TDiceValues;
+}

--- a/server/src/models/IDice.ts
+++ b/server/src/models/IDice.ts
@@ -4,9 +4,9 @@ import { TDiceValues } from "./DiceClass";
 
 export default interface IDice {
   // Getters for public fields
-  diceValues: TDiceValues;
-  whiteDiceSum: number;
-  validColouredNumbers: Partial<Record<rowColour, number[]>>;
+  readonly diceValues: TDiceValues;
+  readonly whiteDiceSum: number;
+  readonly validColouredNumbers: Partial<Record<rowColour, number[]>>;
 
   // Public methods
   rollAllDice(): TDiceValues;

--- a/server/src/models/IDie.ts
+++ b/server/src/models/IDie.ts
@@ -1,0 +1,7 @@
+export default interface IDie {
+    readonly value: number;
+    readonly active: boolean;
+
+    rollDie(): number;
+    disable(): void;
+}

--- a/server/src/models/IPlayer.ts
+++ b/server/src/models/IPlayer.ts
@@ -1,0 +1,18 @@
+import { rowColour } from "../enums/rowColours";
+import IQwixxGameCard from "./IQwixxGameCard";
+import { SerializePlayer, MarkNumberResult } from "./PlayerClass";
+
+export default interface IPlayer {
+  // Getters for public fields
+  name: string;
+  gameCard: IQwixxGameCard;
+  hasSubmittedChoice: boolean;
+  submissionCount: number;
+
+  // Public methods
+  resetSubmission(): void;
+  markSubmitted(): void;
+  markNumber(colour: rowColour, num: number): MarkNumberResult;
+  passMove(): void;
+  serialize(): SerializePlayer
+}

--- a/server/src/models/IQwixxGameCard.ts
+++ b/server/src/models/IQwixxGameCard.ts
@@ -1,0 +1,28 @@
+import { rowColour } from "../enums/rowColours";
+import {
+  SerializeGameCard,
+  RowLocks,
+  RowValues,
+  LockRowResult,
+  GameCardActionResult
+} from "./QwixxBaseGameCard";
+
+export default interface IQwixxGameCard {
+  // Getters for public fields
+  MarkedNumbers: RowValues;
+  Numbers: number[];
+  isLocked: RowLocks;
+  penalties: number[];
+
+  // Public methods
+  serialize(): SerializeGameCard
+  lockRow(row: rowColour): LockRowResult;
+  markNumbers(row: rowColour, number: number): GameCardActionResult;
+  synchronizeLockedRows(rows: rowColour[]): void;
+  addPenalty(): void;
+  getHighestMarkedNumber(row: rowColour): number;
+  getLowestMarkedNumber(row: rowColour): number;
+  hasAvailableMoves(diceValues: Partial<Record<rowColour, number[]>>): boolean;
+  calculateSubtotalScore(): Record<string, number>;
+  calculateScores: () => { subtotal: Record<string, number>; penalties: number, total: number };
+}

--- a/server/src/models/InitializeDice.ts
+++ b/server/src/models/InitializeDice.ts
@@ -1,0 +1,14 @@
+import SixSidedDie from "./SixSidedDieClass"
+import IDie from "./IDie"
+import { DiceColour } from "../enums/DiceColours"
+
+export default function initializeDice(): Record<DiceColour, IDie> {
+  return {
+    [DiceColour.White1]: new SixSidedDie(),
+    [DiceColour.White2]: new SixSidedDie(),
+    [DiceColour.Red]: new SixSidedDie(),
+    [DiceColour.Yellow]: new SixSidedDie(),
+    [DiceColour.Green]: new SixSidedDie(),
+    [DiceColour.Blue]: new SixSidedDie(),
+  }
+}

--- a/server/src/models/LobbyClass.ts
+++ b/server/src/models/LobbyClass.ts
@@ -3,8 +3,9 @@ import Dice from "../models/DiceClass";
 import QwixxLogic from "../services/QwixxLogic";
 import { initializeGameCards } from "./InitializeGameCards";
 import { initializePlayers } from "./InitializePlayer";
-import SixSidedDie from "./SixSidedDieClass";
 import { DiceColour } from "../enums/DiceColours";
+import IQwixxLogic from "../services/IQwixxLogic";
+import initializeDice from "./InitializeDice";
 
 interface SerializedGameState {
   players: Record<string, any>;
@@ -15,7 +16,7 @@ export default class Lobby {
   private _lobbyId: string;
   private _players: string[];
   private _playerObjects: Player[];
-  private _gameLogic: QwixxLogic | null;
+  private _gameLogic: IQwixxLogic | null;
 
   constructor(lobbyId: string) {
     this._lobbyId = lobbyId;
@@ -36,7 +37,7 @@ export default class Lobby {
     return this._playerObjects;
   }
 
-  get gameLogic(): QwixxLogic | null {
+  get gameLogic(): IQwixxLogic | null {
     return this._gameLogic;
   }
 
@@ -60,7 +61,8 @@ export default class Lobby {
   startGame() {
     const gameCards = initializeGameCards(this._players);
     this._playerObjects = initializePlayers(this._players, gameCards);
-    const dice = new Dice(SixSidedDie);
+    const sixSidedDice = initializeDice()
+    const dice = new Dice(sixSidedDice);
     this._gameLogic = new QwixxLogic(this._playerObjects, dice);
 
     return this._gameLogic.serialize();

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -2,6 +2,7 @@ import qwixxBaseGameCard from "./QwixxBaseGameCard";
 import { rowColour } from "../enums/rowColours";
 import { SerializeGameCard } from "./QwixxBaseGameCard";
 import IPlayer from "./IPlayer";
+import IQwixxGameCard from "./IQwixxGameCard";
 
 interface MarkNumberSuccess {
   success: true;
@@ -21,11 +22,11 @@ export interface SerializePlayer {
 
 export default class Player implements IPlayer {
   private _name;
-  private _gameCard: qwixxBaseGameCard;
+  private _gameCard: IQwixxGameCard;
   private _hasSubmittedChoice;
   private _submissionCount;
 
-  constructor(name: string, gameCard: qwixxBaseGameCard) {
+  constructor(name: string, gameCard: IQwixxGameCard) {
     this._name = name;
     this._gameCard = gameCard;
     this._hasSubmittedChoice = false;
@@ -36,7 +37,7 @@ export default class Player implements IPlayer {
     return this._name;
   }
 
-  get gameCard(): qwixxBaseGameCard {
+  get gameCard(): IQwixxGameCard {
     return this._gameCard;
   }
 

--- a/server/src/models/PlayerClass.ts
+++ b/server/src/models/PlayerClass.ts
@@ -1,6 +1,7 @@
 import qwixxBaseGameCard from "./QwixxBaseGameCard";
 import { rowColour } from "../enums/rowColours";
 import { SerializeGameCard } from "./QwixxBaseGameCard";
+import IPlayer from "./IPlayer";
 
 interface MarkNumberSuccess {
   success: true;
@@ -11,14 +12,14 @@ interface MarkNumberFailure {
   errorMessage: string;
 }
 
-type MarkNumberResult = MarkNumberSuccess | MarkNumberFailure;
+export type MarkNumberResult = MarkNumberSuccess | MarkNumberFailure;
 
 export interface SerializePlayer {
   gameCard: SerializeGameCard;
   hasSubmittedChoice: boolean;
 }
 
-export default class Player {
+export default class Player implements IPlayer {
   private _name;
   private _gameCard: qwixxBaseGameCard;
   private _hasSubmittedChoice;
@@ -43,6 +44,10 @@ export default class Player {
     return this._hasSubmittedChoice;
   }
 
+  public get submissionCount(): number {
+    return this._submissionCount;
+  }
+
   public resetSubmission() {
     this._hasSubmittedChoice = false;
     this._submissionCount = 0;
@@ -50,10 +55,6 @@ export default class Player {
 
   public markSubmitted() {
     this._hasSubmittedChoice = true;
-  }
-
-  public get submissionCount(): number {
-    return this._submissionCount;
   }
 
   public markNumber(colour: rowColour, num: number): MarkNumberResult {

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -1,5 +1,5 @@
 import { rowColour } from "../enums/rowColours";
-import IQwixxGameCard from "../tests/models/IQwixxGameCard";
+import IQwixxGameCard from "./IQwixxGameCard";
 
 // TODO: Delete these interfaces and types
 //interface MarkNumbersSuccess {
@@ -103,7 +103,6 @@ export default class qwixxBaseGameCard implements IQwixxGameCard {
    * @param rows - The list of row colors to normalize.
    */
   public synchronizeLockedRows(rows: rowColour[]) {
-    //    this._isLocked[row] = true
     rows.forEach(row => this._isLocked[row] = true)
   }
 
@@ -132,7 +131,7 @@ export default class qwixxBaseGameCard implements IQwixxGameCard {
 
   /**
    * @description Adds a number to the corresponding coloured row if the number is valid.
-   * @returns The result of hte operation, indicating success of failture with an optional error message.
+   * @returns The result of the operation, indicating success or failure with an optional error message.
    * */
   public markNumbers(row: rowColour, number: number): GameCardActionResult {
     if (this._rows[row].includes(number)) {

--- a/server/src/models/QwixxBaseGameCard.ts
+++ b/server/src/models/QwixxBaseGameCard.ts
@@ -14,7 +14,6 @@ import IQwixxGameCard from "./IQwixxGameCard";
 //type MarkNumbersResult = MarkNumbersSuccess | MarkNumbersFailure
 //type IsValidMoveResult = MarkNumbersSuccess | MarkNumbersFailure
 
-
 /**
  * Represents the reuslt of an action that can succeed or fail.
  * - `success: true`: action was successful.
@@ -22,18 +21,20 @@ import IQwixxGameCard from "./IQwixxGameCard";
  */
 export type GameCardActionResult =
   | { success: true }
-  | { success: false; errorMessage: string }
+  | { success: false; errorMessage: string };
 
 // Result for locking rows, which includes additional data in the success case
 export type LockRowResult =
   | { success: true; lockedRow: rowColour }
-  | { success: false; errorMessage?: string }
+  | { success: false; errorMessage?: string };
 
 // Represents the structure of row values on the game card
-export type RowValues = Record<rowColour, number[]>
+export type RowValues = Record<rowColour, number[]>;
+
+export type RowScores = Record<rowColour, number>;
 
 // Represents the locking state of rows on the game card
-export type RowLocks = Record<rowColour, boolean>
+export type RowLocks = Record<rowColour, boolean>;
 
 // Defines the serialized state of a game card
 export interface SerializeGameCard {
@@ -85,7 +86,7 @@ export default class qwixxBaseGameCard implements IQwixxGameCard {
   }
 
   private addNumberToRow(row: rowColour, number: number) {
-    this._rows[row].push(number)
+    this._rows[row].push(number);
   }
 
   public serialize(): SerializeGameCard {
@@ -103,7 +104,7 @@ export default class qwixxBaseGameCard implements IQwixxGameCard {
    * @param rows - The list of row colors to normalize.
    */
   public synchronizeLockedRows(rows: rowColour[]) {
-    rows.forEach(row => this._isLocked[row] = true)
+    rows.forEach((row) => (this._isLocked[row] = true));
   }
 
   /**
@@ -112,21 +113,30 @@ export default class qwixxBaseGameCard implements IQwixxGameCard {
    * */
   public lockRow(row: rowColour): LockRowResult {
     if (row === rowColour.Red || row === rowColour.Yellow) {
-      if (this._rows[row].length < 6 && this.getHighestMarkedNumber(row) !== 12) {
-        return { success: false, errorMessage: "Didn't satisfy conditions to lock a row." }
+      if (
+        this._rows[row].length < 6 &&
+        this.getHighestMarkedNumber(row) !== 12
+      ) {
+        return {
+          success: false,
+          errorMessage: "Didn't satisfy conditions to lock a row.",
+        };
       }
-      this.addNumberToRow(row, 13)
+      this.addNumberToRow(row, 13);
     }
 
     if (row === rowColour.Green || row === rowColour.Blue) {
       if (this._rows[row].length < 6 && this.getLowestMarkedNumber(row) !== 2) {
-        return { success: false, errorMessage: "Didn't satisfy conditions to lock a row." }
+        return {
+          success: false,
+          errorMessage: "Didn't satisfy conditions to lock a row.",
+        };
       }
-      this.addNumberToRow(row, 1)
+      this.addNumberToRow(row, 1);
     }
 
-    this._isLocked[row] = true
-    return { success: true, lockedRow: row }
+    this._isLocked[row] = true;
+    return { success: true, lockedRow: row };
   }
 
   /**
@@ -135,7 +145,10 @@ export default class qwixxBaseGameCard implements IQwixxGameCard {
    * */
   public markNumbers(row: rowColour, number: number): GameCardActionResult {
     if (this._rows[row].includes(number)) {
-      return { success: false, errorMessage: `Number ${number} is already marked in ${row} row.` }
+      return {
+        success: false,
+        errorMessage: `Number ${number} is already marked in ${row} row.`,
+      };
     }
 
     //if (!this.isValidMove(row, number)) {
@@ -145,20 +158,20 @@ export default class qwixxBaseGameCard implements IQwixxGameCard {
     //  }
     //}
 
-    // TODO: Is it better to move this check into 'isValidMove'?
+    // NOTE: Is it better to move this check into 'isValidMove'?
     if (this.isLocked[row]) {
-      return { success: false, errorMessage: `${row} row is already locked.` }
+      return { success: false, errorMessage: `${row} row is already locked.` };
     }
 
-    const res = this.isValidMove(row, number)
+    const res = this.isValidMove(row, number);
 
     if (!res.success) {
-      return { success: res.success, errorMessage: res.errorMessage }
+      return { success: res.success, errorMessage: res.errorMessage };
     }
 
-    this.addNumberToRow(row, number)
+    this.addNumberToRow(row, number);
 
-    return { success: true }
+    return { success: true };
 
     //    this._rows[row].push(number)
 
@@ -169,7 +182,6 @@ export default class qwixxBaseGameCard implements IQwixxGameCard {
     //      return false;
     //    }
   }
-
 
   public addPenalty() {
     this._penalties.push(this._penalties.length + 1);
@@ -196,16 +208,16 @@ export default class qwixxBaseGameCard implements IQwixxGameCard {
         return {
           success: false,
           errorMessage:
-            "Invalid move. Number is not greater than previous marked number"
-        }
+            "Invalid move. Number is not greater than previous marked number",
+        };
       }
       if (num === 12 && this.MarkedNumbers[colour].length < 5) {
         //return this.MarkedNumbers[colour].length >= 5
         return {
           success: false,
           errorMessage:
-            "Number 12 can't be marked. 5 lower values numbers haven't been marked yet"
-        }
+            "Number 12 can't be marked. 5 lower values numbers haven't been marked yet",
+        };
       }
     }
 
@@ -215,15 +227,15 @@ export default class qwixxBaseGameCard implements IQwixxGameCard {
         return {
           success: false,
           errorMessage:
-            "Invalid move. Number is not less than previous marked number"
-        }
+            "Invalid move. Number is not less than previous marked number",
+        };
       }
       if (num === 2 && this.MarkedNumbers[colour].length! < 5) {
         return {
           success: false,
           errorMessage:
-            "Number 2 can't be marked. 5 higher values numbers haven't been marked yet"
-        }
+            "Number 2 can't be marked. 5 higher values numbers haven't been marked yet",
+        };
       }
     }
     return { success: true };
@@ -255,38 +267,45 @@ export default class qwixxBaseGameCard implements IQwixxGameCard {
    * @description Calculates the subtotal score for each row.
    * @returns An object mapping row colors to their respective scores.
    */
-  public calculateSubtotalScore(): Record<string, number> {
-    // NOTE: Would it be more scalable if this multiplier was a part of the constructor? 
+  public calculateSubtotalScore(): Record<rowColour, number> {
+    // NOTE: Would it be more scalable if this multiplier was a part of the constructor?
     const multiplier = [0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66, 78];
 
     return Object.fromEntries(
       Object.entries(this.MarkedNumbers)
         .map(([row, numbers]) => [row, multiplier[numbers.length]])
-    )
+    ) as Record<rowColour, number>
   }
 
   /**
-  * @description Calculates the total score, including subtotals for each row and penalties.
-  * @returns An object containing:
-  * - `subtotal`: A mapping of row colors to their respective scores.
-  * - `penalties`: The total penalty points.
-  * - `total`: The overall score after subtracting penalties.
-  */
-  public calculateScores(): { subtotal: Record<string, number>; penalties: number, total: number } {
+   * @description Calculates the total score, including subtotals for each row and penalties.
+   * @returns An object containing:
+   * - `subtotal`: A mapping of row colors to their respective scores.
+   * - `penalties`: The total penalty points.
+   * - `total`: The overall score after subtracting penalties.
+   */
+  public calculateScores(): {
+    subtotal: Record<rowColour, number>;
+    penalties: number;
+    total: number;
+  } {
     //const multiplier = [0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66, 78]
     //const score = Object.values(this.MarkedNumbers).reduce((score, row) => score + multiplier[row.length], 0)
 
-    const subtotal = this.calculateSubtotalScore()
-    const score = Object.values(subtotal).reduce((sum, rowScore) => sum + rowScore, 0)
-    const penalties = this.calculatePenalties()
-    const total = score - penalties
+    const subtotal = this.calculateSubtotalScore();
+    const score = Object.values(subtotal).reduce(
+      (sum, rowScore) => sum + rowScore,
+      0
+    );
+    const penalties = this.calculatePenalties();
+    const total = score - penalties;
 
     return { subtotal, penalties, total };
   }
 
   private calculatePenalties(): number {
-    const multiplier = 5
-    const penalties = this.penalties.at(-1) || 0
-    return multiplier * penalties
+    const multiplier = 5;
+    const penalties = this.penalties.at(-1) || 0;
+    return multiplier * penalties;
   }
 }

--- a/server/src/models/SixSidedDieClass.ts
+++ b/server/src/models/SixSidedDieClass.ts
@@ -1,4 +1,6 @@
-export default class SixSidedDie {
+import IDie from "./IDie";
+
+export default class SixSidedDie implements IDie {
   private _value: number;
   private _active: boolean;
 

--- a/server/src/models/SixSidedDieClass.ts
+++ b/server/src/models/SixSidedDieClass.ts
@@ -14,6 +14,10 @@ export default class SixSidedDie implements IDie {
   }
 
   rollDie(): number {
+    if (!this._active) {
+      return 0;
+    }
+
     this._value = Math.floor(Math.random() * 6) + 1;
     return this._value;
   }

--- a/server/src/services/IQwixxLogic.ts
+++ b/server/src/services/IQwixxLogic.ts
@@ -1,0 +1,21 @@
+import {
+  RollDiceResult,
+  PassMoveResult,
+  MakeMoveResult,
+  EndTurnResult,
+  ProcessPenaltyResult,
+  LockRowResult,
+  SerializedGameState,
+} from "./QwixxLogic";
+
+export default interface IQwixxLogic {
+  // Getters
+  //Public methods
+  rollDice(): RollDiceResult;
+  passMove(id: string): PassMoveResult;
+  makeMove(id: string, row: string, num: number): MakeMoveResult;
+  endTurn(id: string): EndTurnResult;
+  processPenalty(id: string): ProcessPenaltyResult;
+  lockRow(id: string, row: string): LockRowResult;
+  serialize(): SerializedGameState;
+}

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -77,6 +77,7 @@ export default class QwixxLogic implements IQwixxLogic {
   private _currentTurnIndex: number;
   private _hasRolled: boolean;
   private _lockedRows: rowColour[];
+  private _isGameEnded: boolean;
 
   constructor(players: IPlayer[], dice: IDice) {
     this._playersArray = players;
@@ -84,6 +85,7 @@ export default class QwixxLogic implements IQwixxLogic {
     this._currentTurnIndex = 0;
     this._hasRolled = false;
     this._lockedRows = [];
+    this._isGameEnded = false;
   }
 
   public rollDice(): RollDiceResult {
@@ -132,6 +134,10 @@ export default class QwixxLogic implements IQwixxLogic {
       };
     }
 
+    if (this._isGameEnded) {
+      return { isValid: false, errorMessage: "Can't perform action. Game has already ended." }
+    }
+
     return { isValid: true };
   }
 
@@ -178,7 +184,8 @@ export default class QwixxLogic implements IQwixxLogic {
     if (this.haveAllPlayersSubmitted()) {
       this.handleEndOfRound();
 
-      if (this.isGameEnd()) {
+      if (this.isGameEnd() && !this._isGameEnded) {
+        this._isGameEnded = true;
         const winners = this.determineWinner();
         return { hasGameEnded: true, data: winners };
       }

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -101,8 +101,16 @@ export default class QwixxLogic {
     return this._playersArray[this._currentTurnIndex];
   }
 
-  private playerExistsInLobby(playerName: string): IPlayer | undefined {
-    return this._playersArray.find((player) => player.name === playerName);
+  private playerExistsInLobby(playerName: string): IPlayer {
+    const player = this._playersArray.find(
+      (player) => player.name === playerName
+    );
+
+    if (!player) {
+      throw new Error("Player not found.");
+    }
+
+    return player;
   }
 
   private get hasRolled() {
@@ -194,10 +202,6 @@ export default class QwixxLogic {
     // Call Player Method add submission to player
     const player = this.playerExistsInLobby(playerName);
 
-    if (!player) {
-      throw new Error("Player not found.");
-    }
-
     if (!this.hasRolled) {
       return { success: false, errorMessage: "Dice hasn't been rolled yet." };
     }
@@ -228,10 +232,6 @@ export default class QwixxLogic {
     const player = this.playerExistsInLobby(playerName);
     // Moved this check up to here and early return
     // Only throw error here because critical error and not game-rule violation
-    if (!player) {
-      //return { isValid: false, errorMessage: new Error("Player not found.") };
-      throw new Error("Player not found.");
-    }
 
     //Passed the player object to validateMove instead of playerName
     const validationResult = this.validateMove(player, row, num);
@@ -352,10 +352,6 @@ export default class QwixxLogic {
 
     const player = this.playerExistsInLobby(playerName);
 
-    if (!player) {
-      throw new Error("Player not found.");
-    }
-
     if (player.hasSubmittedChoice) {
       return {
         success: false,
@@ -385,10 +381,7 @@ export default class QwixxLogic {
 
   public processPenalty(playerName: string): ProcessPenaltyResult {
     const player = this.playerExistsInLobby(playerName);
-    if (!player) {
-      throw new Error("Player not found");
-    }
-
+    console.log(player)
     if (player.hasSubmittedChoice) {
       return {
         success: false,
@@ -408,11 +401,7 @@ export default class QwixxLogic {
 
   public lockRow(playerName: string, row: string): LockRowResult {
     const colourToLock = this.getColourFromRow(row);
-
     const player = this.playerExistsInLobby(playerName);
-    if (!player) {
-      throw new Error("Player not found");
-    }
 
     const res = player.gameCard.lockRow(colourToLock);
 

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -229,7 +229,7 @@ export default class QwixxLogic {
       };
     }
 
-    if (player.submissionCount > 1) {
+    if (player.submissionCount > 0) {
       return { success: false, errorMessage: "Cannot pass on second choice." };
     }
 
@@ -296,27 +296,6 @@ export default class QwixxLogic {
       };
     }
 
-    //Checks the non-active player's number selection.
-    if (player !== this.activePlayer && num !== this._dice.whiteDiceSum) {
-      return {
-        isValid: false,
-        errorMessage: "Number selected doesn't equal to sum of white dice.",
-      };
-    }
-
-    //Checks the active player's first number selection is valid.
-    //A valid move for first selection is the sum of the white dice.
-    if (
-      player === this.activePlayer &&
-      player.submissionCount === 0 &&
-      num !== this._dice.whiteDiceSum
-    ) {
-      return {
-        isValid: false,
-        errorMessage: "Number selected doesn't equal to sum of white dice.",
-      };
-    }
-
     //Checks the active player's second number selection is valid.
     //A valid move for the second selection is the sum of a white die + coloured die
     if (
@@ -328,6 +307,14 @@ export default class QwixxLogic {
         isValid: false,
         errorMessage:
           "Number selected doesn't equal to sum of white die and coloured die.",
+      };
+    }
+
+    //General rule: All player's first mark number action needs to be the sum of the white dice.
+    if (num !== this._dice.whiteDiceSum) {
+      return {
+        isValid: false,
+        errorMessage: "Number selected doesn't equal to sum of white dice.",
       };
     }
 

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -244,25 +244,20 @@ export default class QwixxLogic {
   ): MakeMoveResult {
     const rowToMark = this.getColourFromRow(row);
     const player = this.playerExistsInLobby(playerName);
-    const validPrereq = this.validateGameActionPrerequisite(player);
 
+    const validPrereq = this.validateGameActionPrerequisite(player);
     if (!validPrereq.isValid) {
       return { success: false, errorMessage: validPrereq.errorMessage };
     }
 
     const validationResult = this.validateMove(player, rowToMark, num);
-
     if (!validationResult.isValid) {
       return { success: false, errorMessage: validationResult.errorMessage };
     }
 
     const markNumberResult = player.markNumber(rowToMark, num);
-
     if (!markNumberResult.success) {
-      return {
-        success: false,
-        errorMessage: markNumberResult.errorMessage,
-      };
+      return { success: false, errorMessage: markNumberResult.errorMessage };
     }
 
     if (

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -4,8 +4,9 @@ import { TDiceValues } from "../models/DiceClass";
 import { DiceColour } from "../enums/DiceColours";
 import IPlayer from "../models/IPlayer";
 import IDice from "../models/IDice";
+import IQwixxLogic from "./IQwixxLogic";
 
-interface rollDiceResults {
+export interface RollDiceResult {
   hasRolled: boolean;
   hasAvailableMoves: boolean;
   diceValues: TDiceValues;
@@ -46,14 +47,14 @@ interface GameOngoing {
 type ValidationResult = MoveValidationSuccess | MoveValidationFailure;
 type ProcessPlayerSubmissionResult = GameHasEnded | GameOngoing;
 
-interface SerializedGameState {
+export interface SerializedGameState {
   players: Record<string, SerializePlayer>;
   dice: TDiceValues;
   activePlayer: string;
   hasRolled: boolean;
 }
 
-type PassMoveResult =
+export type PassMoveResult =
   | { success: true; data: SerializedGameState }
   | ErrorResult;
 
@@ -62,13 +63,15 @@ type GameActionResult =
   | { success: true; gameEnd: true; data: EndGameSummary }
   | ErrorResult;
 
-type MakeMoveResult = GameActionResult;
-type ProcessPenaltyResult = GameActionResult;
-type EndTurnResult = GameActionResult;
+export type MakeMoveResult = GameActionResult;
+export type ProcessPenaltyResult = GameActionResult;
+export type EndTurnResult = GameActionResult;
 
-type LockRowResult = { success: true; data: SerializedGameState } | ErrorResult;
+export type LockRowResult =
+  | { success: true; data: SerializedGameState }
+  | ErrorResult;
 
-export default class QwixxLogic {
+export default class QwixxLogic implements IQwixxLogic {
   private _playersArray: IPlayer[];
   private _dice: IDice;
   private _currentTurnIndex: number;
@@ -83,7 +86,7 @@ export default class QwixxLogic {
     this._lockedRows = [];
   }
 
-  public rollDice(): rollDiceResults {
+  public rollDice(): RollDiceResult {
     this._hasRolled = true;
     const hasRolled = this.hasRolled;
     const validColouredNumbers = this._dice.validColouredNumbers;

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -290,6 +290,7 @@ export default class QwixxLogic {
         errorMessage: "Dice number is out of range.",
       };
     }
+    //NOTE: What happens if submissionCount > 1?
 
     //Checks the active player's second number selection is valid.
     //A valid move for the second selection is the sum of a white die + coloured die
@@ -306,7 +307,7 @@ export default class QwixxLogic {
     }
 
     //General rule: All player's first mark number action needs to be the sum of the white dice.
-    if (num !== this._dice.whiteDiceSum) {
+    if (player.submissionCount === 0 && num !== this._dice.whiteDiceSum) {
       return {
         isValid: false,
         errorMessage: "Number selected doesn't equal to sum of white dice.",

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -31,7 +31,7 @@ interface EndGameSummary {
 }
 
 // type SuccessResult<T> = { success: true; data: T};
-type ErrorResult = { success: false; errorMessage: string};
+type ErrorResult = { success: false; errorMessage: string };
 
 interface GameHasEnded {
   hasGameEnded: true;
@@ -57,19 +57,16 @@ type PassMoveResult =
   | { success: true; data: SerializedGameState }
   | ErrorResult;
 
-type GameActionResult = 
-  | { success: true; gameEnd: false; data: SerializedGameState} 
-  | { success: true; gameEnd: true; data: EndGameSummary}
-  | ErrorResult
+type GameActionResult =
+  | { success: true; gameEnd: false; data: SerializedGameState }
+  | { success: true; gameEnd: true; data: EndGameSummary }
+  | ErrorResult;
 
-type MakeMoveResult = GameActionResult
-type ProcessPenaltyResult = GameActionResult
-type EndTurnResult = GameActionResult
+type MakeMoveResult = GameActionResult;
+type ProcessPenaltyResult = GameActionResult;
+type EndTurnResult = GameActionResult;
 
-type LockRowResult =
-  | { success: true; data: SerializedGameState }
-  | ErrorResult
-
+type LockRowResult = { success: true; data: SerializedGameState } | ErrorResult;
 
 export default class QwixxLogic {
   private _playersArray: IPlayer[];
@@ -386,17 +383,27 @@ export default class QwixxLogic {
     return { success: true, gameEnd: false, data: this.serialize() };
   }
 
-  public processPenalty(playerName: string) {
+  public processPenalty(playerName: string): ProcessPenaltyResult {
     const player = this.playerExistsInLobby(playerName);
     if (!player) {
       throw new Error("Player not found");
     }
 
+    if (player.hasSubmittedChoice) {
+      return {
+        success: false,
+        errorMessage: "Player has already ended their turn.",
+      };
+    }
+
     player.gameCard.addPenalty();
     player.markSubmitted();
-    this.processPlayersSubmission();
+    const res = this.processPlayersSubmission();
 
-    return this.serialize();
+    if (res.hasGameEnded) {
+      return { success: true, gameEnd: res.hasGameEnded, data: res.data };
+    }
+    return { success: true, gameEnd: res.hasGameEnded, data: this.serialize() };
   }
 
   public lockRow(playerName: string, row: string): LockRowResult {

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -4,6 +4,8 @@ import { rowColour } from "../enums/rowColours";
 import { SerializePlayer } from "../models/PlayerClass";
 import { TDiceValues } from "../models/DiceClass";
 import { DiceColour } from "../enums/DiceColours";
+import IPlayer from "../models/IPlayer";
+import IDice from "../models/IDice";
 
 interface rollDiceResults {
   hasRolled: boolean;
@@ -42,13 +44,13 @@ type LockRowResult =
   | { success: false; errorMessage: string }
 
 export default class QwixxLogic {
-  private _playersArray: Player[];
-  private _dice: Dice;
+  private _playersArray: IPlayer[];
+  private _dice: IDice;
   private _currentTurnIndex: number;
   private _hasRolled: boolean;
   private _lockedRows: rowColour[]
 
-  constructor(players: Player[], dice: Dice) {
+  constructor(players: IPlayer[], dice: IDice) {
     this._playersArray = players;
     this._dice = dice;
     this._currentTurnIndex = 0;
@@ -74,7 +76,7 @@ export default class QwixxLogic {
     return this._playersArray[this._currentTurnIndex];
   }
 
-  private playerExistsInLobby(playerName: string): Player | undefined {
+  private playerExistsInLobby(playerName: string): IPlayer | undefined {
     return this._playersArray.find((player) => player.name === playerName);
   }
 
@@ -219,7 +221,7 @@ export default class QwixxLogic {
   }
 
   private validateMove(
-    player: Player,
+    player: IPlayer,
     row: string,
     num: number
   ): ValidationResult {
@@ -364,8 +366,11 @@ export default class QwixxLogic {
   // }
 
   public calculateScores(): Record<string, number> {
+    // TODO:
+    // we're only using the totals here but calling method actually gives us more information like subtotal
+    // Is there a way we can use that data so we don't have to call calculateScores one more time?
     const scores = this._playersArray.reduce((acc, player) => {
-      acc[player.name] = player.gameCard.calculateScore();
+      acc[player.name] = player.gameCard.calculateScores().total;
       return acc;
     }, {} as Record<string, number>)
 

--- a/server/src/services/QwixxLogic.ts
+++ b/server/src/services/QwixxLogic.ts
@@ -341,14 +341,14 @@ export default class QwixxLogic {
   }
 
   public lockRow(playerName: string, row: string): LockRowResult {
-    const colourToLock = this.getColourFromRow(row)
+    const colourToLock = this.getColourFromRow(row);
 
-    const player = this.playerExistsInLobby(playerName)
+    const player = this.playerExistsInLobby(playerName);
     if (!player) {
-      throw new Error("Player not found")
+      throw new Error("Player not found");
     }
 
-    const res = player.gameCard.lockRow(colourToLock)
+    const res = player.gameCard.lockRow(colourToLock);
 
     if (!res.success) {
       return res
@@ -365,24 +365,26 @@ export default class QwixxLogic {
   //   return this._playersArray;
   // }
 
-  public calculateScores(): Record<string, number> {
-    // TODO:
-    // we're only using the totals here but calling method actually gives us more information like subtotal
-    // Is there a way we can use that data so we don't have to call calculateScores one more time?
-    const scores = this._playersArray.reduce((acc, player) => {
-      acc[player.name] = player.gameCard.calculateScores().total;
-      return acc;
-    }, {} as Record<string, number>)
+  // TODO: Should rename this method
+  public collectPlayersScores() {
+    const playerScores = this._playersArray.map((player) => ({
+      name: player.name,
+      ...player.gameCard.calculateScores(),
+    }));
 
-    return scores
+    return playerScores;
   }
 
   public determineWinner() {
-    const scores = this.calculateScores()
+    const playerScores = this.collectPlayersScores();
+    const highestScore = Math.max(
+      ...playerScores.map((player) => player.total)
+    );
+    const winners = playerScores
+      .filter((player) => player.total === highestScore)
+      .map((player) => player.name);
 
-    return Object.keys(scores).filter(
-      player => scores[player] == Math.max(...Object.values(scores))
-    )
+    return { winners, scores: playerScores };
   }
 
   public serialize(): SerializedGameState {

--- a/server/src/socketHandlers/socketHandlers.ts
+++ b/server/src/socketHandlers/socketHandlers.ts
@@ -201,7 +201,7 @@ export default function initializeSocketHandler(io: Server) {
         // console.log("Updated game state:", res);
 
         if (!res?.success) {
-          const responseData = { message: res?.error };
+          const responseData = { message: res?.errorMessage };
           socket.emit("error_occured", { message: responseData });
           return callback(false);
         }
@@ -274,12 +274,12 @@ export default function initializeSocketHandler(io: Server) {
       try {
         const result = gameState.passMove(userId);
 
-        if (!result.isValid) {
+        if (!result.success) {
           console.log(result.errorMessage);
           socket.emit("error_occurred", { message: result.errorMessage });
         }
 
-        if (result.isValid) {
+        if (result.success) {
           io.to(lobbyId).emit("passMoveProcessed", { gameState: result.data });
           console.log("data for passMove:", result.data);
         }

--- a/server/src/tests/models/DiceClass.integration.test.ts
+++ b/server/src/tests/models/DiceClass.integration.test.ts
@@ -25,8 +25,8 @@ describe("Dice integration tests", () => {
   });
 
   it("should roll all dice and return values within the expected range", () => {
-    testDice.rollAllDice();
-    const diceValues = Object.values(testDice.diceValues);
+    const res = testDice.rollAllDice();
+    const diceValues = Object.values(res);
     diceValues.forEach((value) => {
       expect(value).toBeGreaterThanOrEqual(1);
       expect(value).toBeLessThanOrEqual(6);
@@ -36,9 +36,8 @@ describe("Dice integration tests", () => {
   it("should change the dice values after rolling", () => {
     const initialValues = Object.values(testDice.diceValues);
 
-    testDice.rollAllDice();
-
-    const newValues = Object.values(testDice.diceValues);
+    const res = testDice.rollAllDice();
+    const newValues = Object.values(res);
 
     expect(initialValues).not.toEqual(newValues);
   });
@@ -47,9 +46,9 @@ describe("Dice integration tests", () => {
     testDice.rollAllDice();
 
     testDice.disableDie(DiceColour.Red);
-    testDice.rollAllDice();
+    const res = testDice.rollAllDice();
 
-    expect(testDice.diceValues["red"]).toBe(0);
+    expect(res.red).toBe(0);
   });
 
   test("disabling a non-existant die should not throw an error", () => {
@@ -62,8 +61,7 @@ describe("Dice integration tests", () => {
     const diceValues = testDice.rollAllDice();
     const num = diceValues.white1 + diceValues.red;
 
-    expect(
-      testDice.validColouredNumbers[DiceColour.Red]?.includes(num)
-    ).toBeTruthy();
+    const validColouredNums = testDice.validColouredNumbers;
+    expect(validColouredNums.red?.includes(num)).toBeTruthy();
   });
 });

--- a/server/src/tests/models/DiceClass.integration.test.ts
+++ b/server/src/tests/models/DiceClass.integration.test.ts
@@ -6,7 +6,15 @@ let testDice: Dice;
 
 describe("Dice integration tests", () => {
   beforeEach(() => {
-    testDice = new Dice(SixSidedDie);
+    const dice = {
+      [DiceColour.White1]: new SixSidedDie(),
+      [DiceColour.White2]: new SixSidedDie(),
+      [DiceColour.Red]: new SixSidedDie(),
+      [DiceColour.Yellow]: new SixSidedDie(),
+      [DiceColour.Green]: new SixSidedDie(),
+      [DiceColour.Blue]: new SixSidedDie(),
+    };
+    testDice = new Dice(dice);
   });
 
   it("should initialize with all dice values as 1", () => {
@@ -52,9 +60,10 @@ describe("Dice integration tests", () => {
 
   test("validColouredNumbers returns an object of valid number", () => {
     const diceValues = testDice.rollAllDice();
-
     const num = diceValues.white1 + diceValues.red;
 
-    expect(testDice.validColouredNumbers["red"]?.includes(num)).toBeTruthy();
-  })
+    expect(
+      testDice.validColouredNumbers[DiceColour.Red]?.includes(num)
+    ).toBeTruthy();
+  });
 });

--- a/server/src/tests/models/DiceClass.unit.test.ts
+++ b/server/src/tests/models/DiceClass.unit.test.ts
@@ -1,26 +1,47 @@
 import Dice from "../../models/DiceClass";
 import SixSidedDie from "../../models/SixSidedDieClass";
 import IDice from "../../models/IDice";
+import IDie from "../../models/IDie";
 import { DiceColour } from "../../enums/DiceColours";
+
+const createDieMock = (): jest.Mocked<IDie> => {
+  return {
+    get value(){
+      return 1
+    },
+    get active(){
+      return true;
+    },
+    rollDie: jest.fn(),
+    disable: jest.fn(),
+  }
+}
+
+const mockSixSidedDice = {
+  [DiceColour.White1]: createDieMock(),
+  [DiceColour.White2]: createDieMock(),
+  [DiceColour.Red]: createDieMock(),
+  [DiceColour.Yellow]: createDieMock(),
+  [DiceColour.Green]: createDieMock(),
+  [DiceColour.Blue]: createDieMock(),
+}
 
 describe("DiceClass unit test", () => {
   let testDice: IDice;
   beforeEach(() => {
-    testDice = new Dice(SixSidedDie);
+    testDice = new Dice(mockSixSidedDice);
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
   it("should return valid sums when dice values are positive numbers", () => {
-    SixSidedDie.prototype.rollDie = jest
-      .fn()
-      .mockReturnValueOnce(2) // Mock for White1
-      .mockReturnValueOnce(3) // Mock for White2
-      .mockReturnValueOnce(4) // Mock for Red
-      .mockReturnValueOnce(6) // Mock for Yellow (should be ignored)
-      .mockReturnValueOnce(5) // Mock for Green
-      .mockReturnValueOnce(1); // Mock for Blue (should be ignored)
+    mockSixSidedDice[DiceColour.White1].rollDie.mockReturnValue(2)
+    mockSixSidedDice[DiceColour.White2].rollDie.mockReturnValue(3)
+    mockSixSidedDice[DiceColour.Red].rollDie.mockReturnValue(4)
+    mockSixSidedDice[DiceColour.Yellow].rollDie.mockReturnValue(6)
+    mockSixSidedDice[DiceColour.Green].rollDie.mockReturnValue(5)
+    mockSixSidedDice[DiceColour.Blue].rollDie.mockReturnValue(1)
 
     const expectedNumbers = {
       red: [6, 7],
@@ -37,20 +58,16 @@ describe("DiceClass unit test", () => {
   });
 
   it("should ignore sums involving dice values of 0", () => {
-    SixSidedDie.prototype.rollDie = jest
-      .fn()
-      .mockReturnValueOnce(2)
-      .mockReturnValueOnce(3)
-      .mockReturnValueOnce(4)
-      .mockReturnValueOnce(0)
-      .mockReturnValueOnce(5)
-      .mockReturnValueOnce(0);
+    mockSixSidedDice[DiceColour.White1].rollDie.mockReturnValue(2)
+    mockSixSidedDice[DiceColour.White2].rollDie.mockReturnValue(3)
+    mockSixSidedDice[DiceColour.Red].rollDie.mockReturnValue(4)
+    mockSixSidedDice[DiceColour.Yellow].rollDie.mockReturnValue(0)
+    mockSixSidedDice[DiceColour.Green].rollDie.mockReturnValue(5)
+    mockSixSidedDice[DiceColour.Blue].rollDie.mockReturnValue(0)
 
     const expectedNumbers = {
       red: [6, 7],
-      // yellow: [],
       green: [7, 8],
-      // blue: [],
     };
 
     testDice.rollAllDice();
@@ -61,14 +78,12 @@ describe("DiceClass unit test", () => {
   });
 
   it("should ignore sums involving dice of negative values", () => {
-    SixSidedDie.prototype.rollDie = jest
-      .fn()
-      .mockReturnValueOnce(2)
-      .mockReturnValueOnce(3)
-      .mockReturnValueOnce(-3)
-      .mockReturnValueOnce(-4)
-      .mockReturnValueOnce(5)
-      .mockReturnValueOnce(-1);
+    mockSixSidedDice[DiceColour.White1].rollDie.mockReturnValue(2)
+    mockSixSidedDice[DiceColour.White2].rollDie.mockReturnValue(3)
+    mockSixSidedDice[DiceColour.Red].rollDie.mockReturnValue(-3)
+    mockSixSidedDice[DiceColour.Yellow].rollDie.mockReturnValue(-4)
+    mockSixSidedDice[DiceColour.Green].rollDie.mockReturnValue(5)
+    mockSixSidedDice[DiceColour.Blue].rollDie.mockReturnValue(-1)
 
     const expectedNumbers = {
       green: [7, 8],
@@ -82,14 +97,12 @@ describe("DiceClass unit test", () => {
   });
 
   it("should hanlde duplicate sums for duplicate values", () => {
-    SixSidedDie.prototype.rollDie = jest
-      .fn()
-      .mockReturnValueOnce(2)
-      .mockReturnValueOnce(2)
-      .mockReturnValueOnce(5)
-      .mockReturnValueOnce(4)
-      .mockReturnValueOnce(5)
-      .mockReturnValueOnce(4);
+    mockSixSidedDice[DiceColour.White1].rollDie.mockReturnValue(2)
+    mockSixSidedDice[DiceColour.White2].rollDie.mockReturnValue(2)
+    mockSixSidedDice[DiceColour.Red].rollDie.mockReturnValue(5)
+    mockSixSidedDice[DiceColour.Yellow].rollDie.mockReturnValue(4)
+    mockSixSidedDice[DiceColour.Green].rollDie.mockReturnValue(5)
+    mockSixSidedDice[DiceColour.Blue].rollDie.mockReturnValue(4)
 
     const expectedNumbers = {
       red: [7, 7],
@@ -104,12 +117,3 @@ describe("DiceClass unit test", () => {
     expect(validColouredNumbers).toEqual(expectedNumbers);
   });
 });
-
-// diceValues = {
-//   red: [3,5],
-//   yellow: [4,6],
-//   green: [8,5],
-//   blue: [3,4],
-// }
-
-// !validColouredNumbers[colourToMark].includes(num)

--- a/server/src/tests/models/DiceClass.unit.test.ts
+++ b/server/src/tests/models/DiceClass.unit.test.ts
@@ -1,9 +1,10 @@
 import Dice from "../../models/DiceClass";
 import SixSidedDie from "../../models/SixSidedDieClass";
+import IDice from "../../models/IDice";
 import { DiceColour } from "../../enums/DiceColours";
 
 describe("DiceClass unit test", () => {
-  let testDice: Dice;
+  let testDice: IDice;
   beforeEach(() => {
     testDice = new Dice(SixSidedDie);
   });

--- a/server/src/tests/models/PlayerClass.unit.test.ts
+++ b/server/src/tests/models/PlayerClass.unit.test.ts
@@ -1,8 +1,8 @@
 import { rowColour } from "../../enums/rowColours";
+import IQwixxGameCard from "../../models/IQwixxGameCard";
 import Player from "../../models/PlayerClass";
-import qwixxBaseGameCard from "../../models/QwixxBaseGameCard";
 
-const mockGameCard: Partial<qwixxBaseGameCard> = {
+const mockGameCard: Partial<IQwixxGameCard> = {
   markNumbers: jest.fn(),
 };
 
@@ -10,7 +10,7 @@ let testPlayer: Player;
 
 describe("Player Class tests", () => {
   beforeEach(() => {
-    testPlayer = new Player("testPlayer", mockGameCard as qwixxBaseGameCard);
+    testPlayer = new Player("testPlayer", mockGameCard as IQwixxGameCard);
   });
 
   it("Should take a name and be able to return it", () => {

--- a/server/src/tests/models/QwixxBaseGameCard.test.ts
+++ b/server/src/tests/models/QwixxBaseGameCard.test.ts
@@ -244,26 +244,63 @@ describe("Base Game Card test", () => {
     });
   });
 
-  describe("Calculate Score", () => {
+  describe("Calculate Score:", () => {
+    it("can calculate the subtotal score", () => {
+      for (let i = 2; i < 13; i++) {
+        testGameCard.markNumbers(rowColour.Red, i);
+      }
+      for (let i = 2; i < 13; i++) {
+        testGameCard.markNumbers(rowColour.Yellow, i);
+      }
+      for (let i = 12; i > 1; i--) {
+        testGameCard.markNumbers(rowColour.Green, i);
+      }
+      for (let i = 12; i > 1; i--) {
+        testGameCard.markNumbers(rowColour.Blue, i);
+      }
+
+      const expected = { red: 66, yellow: 66, green: 66, blue: 66 }
+      const res = testGameCard.calculateSubtotalScore()
+      expect(res).toEqual(expected)
+    })
+
     it("can calculate the score with a single marked number", () => {
       testGameCard.markNumbers(rowColour.Red, 2);
-      const res = testGameCard.calculateScore();
-      expect(res).toEqual(1);
+      const res = testGameCard.calculateScores();
+      expect(res).toEqual(
+        {
+          total: 1,
+          subtotal: { red: 1, yellow: 0, green: 0, blue: 0 },
+          penalties: 0,
+        }
+      );
     });
 
     it("can calculate the score with a two marked number", () => {
       testGameCard.markNumbers(rowColour.Red, 2);
       testGameCard.markNumbers(rowColour.Red, 3);
-      const res = testGameCard.calculateScore();
-      expect(res).toEqual(3);
+      const res = testGameCard.calculateScores();
+      expect(res).toEqual(
+        {
+          total: 3,
+          subtotal: { red: 3, yellow: 0, green: 0, blue: 0 },
+          penalties: 0,
+        }
+      );
     });
 
     it("can calculate the score including the 13th marked number", () => {
       for (let i = 2; i < 14; i++) {
         testGameCard.markNumbers(rowColour.Red, i);
       }
-      const res = testGameCard.calculateScore();
-      expect(res).toEqual(78);
+      const res = testGameCard.calculateScores();
+      expect(res).toEqual(
+        {
+          total: 78,
+          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+          penalties: 0,
+        }
+      );
     });
 
     it("can calculate the score of multiple rows", () => {
@@ -280,8 +317,14 @@ describe("Base Game Card test", () => {
         testGameCard.markNumbers(rowColour.Blue, i);
       }
 
-      const res = testGameCard.calculateScore();
-      expect(res).toEqual(264);
+      const res = testGameCard.calculateScores();
+      expect(res).toEqual(
+        {
+          total: 264,
+          subtotal: { red: 66, yellow: 66, green: 66, blue: 66 },
+          penalties: 0,
+        }
+      );
     });
 
     it("calculates the total score while factoring 1 penalty", () => {
@@ -290,8 +333,14 @@ describe("Base Game Card test", () => {
       }
 
       testGameCard.addPenalty();
-      const res = testGameCard.calculateScore();
-      expect(res).toEqual(73);
+      const res = testGameCard.calculateScores();
+      expect(res).toEqual(
+        {
+          total: 73,
+          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+          penalties: 5,
+        }
+      );
     });
 
     it("calculates the total score while factoring 2 penalties", () => {
@@ -301,8 +350,14 @@ describe("Base Game Card test", () => {
 
       testGameCard.addPenalty();
       testGameCard.addPenalty();
-      const res = testGameCard.calculateScore();
-      expect(res).toEqual(68);
+      const res = testGameCard.calculateScores();
+      expect(res).toEqual(
+        {
+          total: 68,
+          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+          penalties: 10,
+        }
+      );
     });
   });
 });

--- a/server/src/tests/models/QwixxBaseGameCard.test.ts
+++ b/server/src/tests/models/QwixxBaseGameCard.test.ts
@@ -232,7 +232,7 @@ describe("Base Game Card test", () => {
     );
 
     test("Can normalise rows", () => {
-      testGameCard.normaliseRows([rowColour.Red, rowColour.Blue]);
+      testGameCard.synchronizeLockedRows([rowColour.Red, rowColour.Blue]);
 
       const lockedRows = testGameCard.isLocked;
       expect(lockedRows).toEqual({

--- a/server/src/tests/models/__mocks__/MockedInterfaces.ts
+++ b/server/src/tests/models/__mocks__/MockedInterfaces.ts
@@ -1,0 +1,131 @@
+import { rowColour } from "../../../enums/rowColours";
+import IPlayer from "../../../models/IPlayer";
+import IQwixxGameCard from "../../../models/IQwixxGameCard";
+import IDice from "../../../models/IDice";
+
+// TODO: Need player mocks where they have submitted choice and haven't submitted choice
+export const player1Mock: jest.Mocked<IPlayer> = {
+  get name() {
+    return "Player1";
+  },
+  get gameCard() {
+    return GameCardLockedRedRowMock;
+  },
+  get hasSubmittedChoice() {
+    return false;
+  },
+  get submissionCount() {
+    return 2;
+  },
+
+  resetSubmission: jest.fn(),
+  markSubmitted: jest.fn(),
+  markNumber: jest.fn().mockReturnValue({ success: true }),
+  passMove: jest.fn(),
+  serialize: jest.fn(),
+};
+
+export const player2Mock: jest.Mocked<IPlayer> = {
+  get name() {
+    return "Player2";
+  },
+  get gameCard() {
+    return GameCardLockedYellowRowMock;
+  },
+  get hasSubmittedChoice() {
+    return true;
+  },
+  get submissionCount() {
+    return 2;
+  },
+
+  resetSubmission: jest.fn(),
+  markSubmitted: jest.fn(),
+  markNumber: jest.fn().mockReturnValue({ success: true }),
+  passMove: jest.fn(),
+  serialize: jest.fn(),
+};
+
+export const GameCardLockedRedRowMock: jest.Mocked<IQwixxGameCard> = {
+  // Methods
+  markNumbers: jest.fn(),
+  calculateScores: jest.fn().mockReturnValue({
+    penalties: 0,
+    total: 48,
+    subtotal: { red: 12, yellow: 12, green: 12, blue: 12 },
+  }),
+  lockRow: jest
+    .fn()
+    .mockReturnValue({ success: true, lockedRow: rowColour.Red })
+    .mockReturnValue({ success: true, lockedRow: rowColour.Blue }),
+  serialize: jest.fn(),
+  addPenalty: jest.fn(),
+  getHighestMarkedNumber: jest.fn(),
+  getLowestMarkedNumber: jest.fn(),
+  hasAvailableMoves: jest.fn(),
+  calculateSubtotalScore: jest.fn(),
+  synchronizeLockedRows: jest.fn(),
+
+  // Getters
+  get MarkedNumbers() {
+    return { red: [], yellow: [], green: [], blue: [] }; // Mocked RowValues
+  },
+  get Numbers() {
+    return [1, 2, 3, 4];
+  },
+  get isLocked() {
+    return { red: false, yellow: false, green: false, blue: false }; // Mocked RowLocks
+  },
+  get penalties() {
+    return [];
+  },
+};
+
+export const GameCardLockedYellowRowMock: jest.Mocked<IQwixxGameCard> = {
+  // Methods
+  markNumbers: jest.fn(),
+  calculateScores: jest.fn().mockReturnValue({
+    penalties: 0,
+    total: 38,
+    subtotal: { red: 12, yellow: 12, green: 12, blue: 0 },
+  }),
+  lockRow: jest
+    .fn()
+    .mockReturnValue({ success: true, lockedRow: rowColour.Yellow }),
+  serialize: jest.fn(),
+  addPenalty: jest.fn(),
+  getHighestMarkedNumber: jest.fn(),
+  getLowestMarkedNumber: jest.fn(),
+  hasAvailableMoves: jest.fn(),
+  calculateSubtotalScore: jest.fn(),
+  synchronizeLockedRows: jest.fn(),
+
+  // Getters
+  get MarkedNumbers() {
+    return { red: [], yellow: [], green: [], blue: [] }; // Mocked RowValues
+  },
+  get Numbers() {
+    return [1, 2, 3, 4];
+  },
+  get isLocked() {
+    return { red: false, yellow: false, green: false, blue: false }; // Mocked RowLocks
+  },
+  get penalties() {
+    return [];
+  },
+};
+
+export const diceMock: jest.Mocked<IDice> = {
+  get diceValues() {
+    return { white1: 6, white2: 6, red: 6, yellow: 6, green: 6, blue: 6 };
+  },
+  get whiteDiceSum() {
+    return 12;
+  },
+  get validColouredNumbers() {
+    return { red: [12, 12], yellow: [12, 12], green: [12, 12], blue: [12, 12] };
+  },
+  rollAllDice: jest.fn(),
+  disableDie: jest.fn(),
+  serialize: jest.fn(),
+};

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -14,7 +14,6 @@ jest.mock("../../models/SixSidedDieClass");
 
 const SixSidedDieMock = SixSidedDie as jest.MockedClass<typeof SixSidedDie>;
 
-
 // Set up the behavior of all `rollDie()` calls
 describe("Qwixx Logic integration tests:", () => {
   beforeEach(() => {
@@ -255,21 +254,21 @@ describe("Qwixx Logic integration tests:", () => {
     );
 
     test("active-player can mark a number that equals the sum of the white dice", () => {
-      testGame.rollDice()
-      const res = testGame.makeMove("test-player1", "red", 5)
+      testGame.rollDice();
+      const res = testGame.makeMove("test-player1", "red", 5);
 
-      if(!res.success){
-        throw new Error()
+      if (!res.success) {
+        throw new Error();
       }
 
-      if(res.gameEnd){
-        throw new Error()
+      if (res.gameEnd) {
+        throw new Error();
       }
 
       expect(res.success).toBeTruthy();
       expect(res.data.players["test-player1"].hasSubmittedChoice).toBeFalsy();
-      expect(res.data.players["test-player1"].gameCard.rows.red).toEqual([5])
-    })
+      expect(res.data.players["test-player1"].gameCard.rows.red).toEqual([5]);
+    });
 
     //TODO: Maybe can use .each() here
     // Check this test is working
@@ -333,30 +332,36 @@ describe("Qwixx Logic integration tests:", () => {
 
     test("non-active player can mark a number equal to the sum of the white dice", () => {
       testGame.rollDice();
-      const res = testGame.makeMove("test-player2", "red", 5)
+      const res = testGame.makeMove("test-player2", "red", 5);
 
-      if(!res.success){
-        throw new Error("Marking a number equal to sum of white dice should be sucessful.")
+      if (!res.success) {
+        throw new Error(
+          "Marking a number equal to sum of white dice should be sucessful."
+        );
       }
 
-      if(res.gameEnd){
-        throw new Error("Game shouldn't have ended.")
+      if (res.gameEnd) {
+        throw new Error("Game shouldn't have ended.");
       }
 
-      expect(res.success).toBeTruthy()
-      expect(res.data.players["test-player2"].hasSubmittedChoice).toBeTruthy()
-    })
+      expect(res.success).toBeTruthy();
+      expect(res.data.players["test-player2"].hasSubmittedChoice).toBeTruthy();
+    });
 
     test("non-active player marking a number that doesn't equal to the sum of the white dice should return an error", () => {
       testGame.rollDice();
-      const res = testGame.makeMove("test-player2", "red", 6)
-      if(res.success){
-        throw new Error("Marking a number that doesnt' equal sum of white dice should fail.")
+      const res = testGame.makeMove("test-player2", "red", 6);
+      if (res.success) {
+        throw new Error(
+          "Marking a number that doesnt' equal sum of white dice should fail."
+        );
       }
 
-      expect(res.success).toBeFalsy()
-      expect(res.errorMessage).toBe("Number selected doesn't equal to sum of white dice.")
-    })
+      expect(res.success).toBeFalsy();
+      expect(res.errorMessage).toBe(
+        "Number selected doesn't equal to sum of white dice."
+      );
+    });
   });
 
   describe("end turn tests", () => {
@@ -417,5 +422,20 @@ describe("Qwixx Logic integration tests:", () => {
         );
       }
     });
+  });
+
+  test("Can't end a turn if a dice hasn't been rolled", () => {
+    const res = testGame.endTurn("test-player1");
+
+    if (res.success) {
+      throw new Error();
+    }
+    expect(res.success).toBeFalsy();
+    expect(res.errorMessage).toBe("Dice hasn't been rolled yet.");
+  });
+
+  test("should throw an error if player not found", () => {
+    testGame.rollDice();
+    expect(() => testGame.endTurn("player3")).toThrow("Player not found");
   });
 });

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -1,37 +1,24 @@
 import QwixxLogic from "../../services/QwixxLogic";
 import qwixxBaseGameCard from "../../models/QwixxBaseGameCard";
 import Player from "../../models/PlayerClass";
-import SixSidedDie from "../../models/SixSidedDieClass";
 import Dice from "../../models/DiceClass";
-import IDice from "../../models/IDice";
+import { mockSixSidedDice } from "./__mocks__/QwixxLogicTestMocks";
+
 let mockPlayersArray: Player[];
 let mockDice: Dice;
 let testGame: QwixxLogic;
 let mockPlayer1: Player;
 let mockPlayer2: Player;
 
-jest.mock("../../models/SixSidedDieClass");
-
-const SixSidedDieMock = SixSidedDie as jest.MockedClass<typeof SixSidedDie>;
-
-// Set up the behavior of all `rollDie()` calls
 describe("Qwixx Logic integration tests:", () => {
   beforeEach(() => {
-    SixSidedDieMock.prototype.rollDie
-      .mockImplementationOnce(() => 2)
-      .mockImplementationOnce(() => 3)
-      .mockImplementationOnce(() => 4)
-      .mockImplementationOnce(() => 5)
-      .mockImplementationOnce(() => 6)
-      .mockImplementationOnce(() => 1);
-
     const mockgameCard1 = new qwixxBaseGameCard();
     mockPlayer1 = new Player("test-player1", mockgameCard1);
 
     const mockgameCard2 = new qwixxBaseGameCard();
     mockPlayer2 = new Player("test-player2", mockgameCard2);
 
-    mockDice = new Dice(SixSidedDieMock);
+    mockDice = new Dice(mockSixSidedDice);
 
     mockPlayersArray = [mockPlayer1, mockPlayer2];
 

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -3,7 +3,7 @@ import qwixxBaseGameCard from "../../models/QwixxBaseGameCard";
 import Player from "../../models/PlayerClass";
 import SixSidedDie from "../../models/SixSidedDieClass";
 import Dice from "../../models/DiceClass";
-
+import IDice from "../../models/IDice";
 let mockPlayersArray: Player[];
 let mockDice: Dice;
 let testGame: QwixxLogic;
@@ -13,6 +13,7 @@ let mockPlayer2: Player;
 jest.mock("../../models/SixSidedDieClass");
 
 const SixSidedDieMock = SixSidedDie as jest.MockedClass<typeof SixSidedDie>;
+
 
 // Set up the behavior of all `rollDie()` calls
 describe("Qwixx Logic integration tests:", () => {
@@ -44,12 +45,16 @@ describe("Qwixx Logic integration tests:", () => {
 
   describe("Game logic tests", () => {
     test("making a move before rolling dice throws an error", () => {
-      const res = testGame.makeMove("test-player1", "red", 2)
+      const res = testGame.makeMove("test-player1", "red", 2);
 
-      expect(res.success).toBeFalsy()
-      if (!res.success) {
-        expect(res.error).toBe("Dice hasn't been rolled yet.")
+      if (res.success) {
+        throw new Error(
+          "Making a move before rolling a dice shouldn't be successful."
+        );
       }
+
+      expect(res.success).toBeFalsy();
+      expect(res.errorMessage).toBe("Dice hasn't been rolled yet.");
     });
 
     it("should make a move and return the correct result", () => {
@@ -58,27 +63,34 @@ describe("Qwixx Logic integration tests:", () => {
 
       const gameState = testGame.makeMove("test-player2", "red", whiteDiceSum);
 
-      if (gameState.success) {
-        expect(gameState.data.players).toHaveProperty("test-player1")
-        expect(gameState.data.players).toHaveProperty("test-player2");
-        expect(gameState.data.players["test-player1"].gameCard).toHaveProperty(
-          "penalties",
-          []
-        );
-        expect(gameState.data.players["test-player2"].gameCard).toHaveProperty(
-          "penalties",
-          []
-        );
-
-        expect(gameState.data.dice).toMatchObject({
-          white1: expect.any(Number),
-          white2: expect.any(Number),
-          red: expect.any(Number),
-          yellow: expect.any(Number),
-          green: expect.any(Number),
-          blue: expect.any(Number),
-        });
+      if (!gameState.success) {
+        throw new Error("Making a move should be successful.");
       }
+
+      if (gameState.gameEnd) {
+        throw new Error("Game shouldn't have ended.");
+      }
+
+      expect(gameState.success && !gameState.gameEnd).toBeTruthy();
+      expect(gameState.data.players).toHaveProperty("test-player1");
+      expect(gameState.data.players).toHaveProperty("test-player2");
+      expect(gameState.data.players["test-player1"].gameCard).toHaveProperty(
+        "penalties",
+        []
+      );
+      expect(gameState.data.players["test-player2"].gameCard).toHaveProperty(
+        "penalties",
+        []
+      );
+
+      expect(gameState.data.dice).toMatchObject({
+        white1: expect.any(Number),
+        white2: expect.any(Number),
+        red: expect.any(Number),
+        yellow: expect.any(Number),
+        green: expect.any(Number),
+        blue: expect.any(Number),
+      });
     });
 
     test("when all players have submitted a move, it should go to the next turn by making the next player the active player", () => {
@@ -87,20 +99,20 @@ describe("Qwixx Logic integration tests:", () => {
       expect(initialGameState.activePlayer).toBe("test-player1");
 
       const firstMoveState = testGame.makeMove("test-player1", "red", 5);
-      expect(firstMoveState.success).toBeTruthy()
-      if (firstMoveState.success) {
+      expect(firstMoveState.success).toBeTruthy();
+      if (firstMoveState.success && !firstMoveState.gameEnd) {
         expect(firstMoveState.data.activePlayer).toBe("test-player1");
       }
 
       const secondMoveState = testGame.makeMove("test-player1", "red", 7);
-      expect(secondMoveState.success).toBeTruthy()
-      if (secondMoveState.success) {
+      expect(secondMoveState.success).toBeTruthy();
+      if (secondMoveState.success && !secondMoveState.gameEnd) {
         expect(secondMoveState.data.activePlayer).toBe("test-player1");
       }
 
       const finalMoveState = testGame.makeMove("test-player2", "blue", 5);
-      expect(finalMoveState).toBeTruthy()
-      if (finalMoveState.success) {
+      expect(finalMoveState).toBeTruthy();
+      if (finalMoveState.success && !finalMoveState.gameEnd) {
         expect(finalMoveState.data.activePlayer).toBe("test-player2");
       }
     });
@@ -147,13 +159,15 @@ describe("Qwixx Logic integration tests:", () => {
 
     it("should roll all dice and return whether active player has available moves", () => {
       const result = testGame.rollDice();
-      expect(result.hasAvailableMoves).toBeTruthy()
-    })
+      expect(result.hasAvailableMoves).toBeTruthy();
+    });
 
     it("should roll all the dice and return the value of hasRolled as true", () => {
       const result = testGame.rollDice();
-      expect(result.hasRolled).toBeTruthy()
-    })
+      expect(result.hasRolled).toBeTruthy();
+    });
+
+    //TODO: UNIT TEST when rolling a dice returns the active player not having available moves.
   });
 
   describe("active player tests", () => {
@@ -170,11 +184,12 @@ describe("Qwixx Logic integration tests:", () => {
       testGame.rollDice();
       testGame.makeMove("test-player1", "red", 5);
       testGame.makeMove("test-player1", "red", 7);
-      const result = testGame.makeMove("test-player1", "yellow", 7)
-      expect(result.success).toBeFalsy()
-      if (!result.success) {
-        expect(result.error)
+      const result = testGame.makeMove("test-player1", "yellow", 7);
+      if (result.success) {
+        throw new Error("Can't submit more than 2 actions.");
       }
+      expect(result.success).toBeFalsy();
+      expect(result.errorMessage).toBe("Player already finished their turn.");
     });
 
     test("current player's hasSubmittedChoice is updated after submitting 2 moves", () => {
@@ -199,11 +214,14 @@ describe("Qwixx Logic integration tests:", () => {
 
       testGame.rollDice();
 
-      const result = testGame.makeMove("test-player1", "red", 9)
-      expect(result.success).toBeFalsy()
-      if (!result.success) {
-        expect(result.error).toBe("Number selected doesn't equal to sum of white dice.")
+      const result = testGame.makeMove("test-player1", "red", 9);
+      if (result.success) {
+        throw new Error("Marking an invalid number should be unsuccessful.");
       }
+      expect(result.success).toBeFalsy();
+      expect(result.errorMessage).toBe(
+        "Number selected doesn't equal to sum of white dice."
+      );
     });
 
     test.each([
@@ -216,32 +234,53 @@ describe("Qwixx Logic integration tests:", () => {
       (row, num) => {
         jest.spyOn(mockPlayer1, "submissionCount", "get").mockReturnValue(1);
 
-        jest
-          .spyOn(mockDice, "validColouredNumbers", "get")
-          // .mockReturnValue([3, 4, 5, 6, 7, 8, 7, 2])
-          .mockReturnValue({
-            red: [3, 7],
-            yellow: [4, 8],
-            green: [5, 7],
-            blue: [6, 2],
-          });
+        jest.spyOn(mockDice, "validColouredNumbers", "get").mockReturnValue({
+          red: [3, 7],
+          yellow: [4, 8],
+          green: [5, 7],
+          blue: [6, 2],
+        });
 
         testGame.rollDice();
 
         const result = testGame.makeMove("test-player1", row, num);
-        expect(result.success).toBeFalsy()
-        if (!result.success) {
-          expect(result.error).toBe("Number selected doesn't equal to sum of white die and coloured die.")
+        if (result.success) {
+          throw new Error("Marking an invalid number should be unsuccessful.");
         }
+        expect(result.success).toBeFalsy();
+        expect(result.errorMessage).toBe(
+          "Number selected doesn't equal to sum of white die and coloured die."
+        );
       }
     );
 
+    test("active-player can mark a number that equals the sum of the white dice", () => {
+      testGame.rollDice()
+      const res = testGame.makeMove("test-player1", "red", 5)
+
+      if(!res.success){
+        throw new Error()
+      }
+
+      if(res.gameEnd){
+        throw new Error()
+      }
+
+      expect(res.success).toBeTruthy();
+      expect(res.data.players["test-player1"].hasSubmittedChoice).toBeFalsy();
+      expect(res.data.players["test-player1"].gameCard.rows.red).toEqual([5])
+    })
+
+    //TODO: Maybe can use .each() here
+    // Check this test is working
     test("active-player can mark a number that equals the sum of a white and a coloured die", () => {
       const diceResults = testGame.rollDice();
-      const firstNumber = diceResults.diceValues.white1 + diceResults.diceValues.white2;
+      const firstNumber =
+        diceResults.diceValues.white1 + diceResults.diceValues.white2;
       testGame.makeMove("test-player1", "blue", firstNumber);
 
-      const secondNumber = diceResults.diceValues.white1 + diceResults.diceValues.red;
+      const secondNumber =
+        diceResults.diceValues.white1 + diceResults.diceValues.red;
 
       const validNumbers = mockDice.validColouredNumbers;
 
@@ -273,9 +312,9 @@ describe("Qwixx Logic integration tests:", () => {
       testGame.makeMove("test-player2", "red", 5);
 
       const result = testGame.makeMove("test-player2", "red", 7);
-      expect(result.success).toBeFalsy()
+      expect(result.success).toBeFalsy();
       if (!result.success) {
-        expect(result.error).toBe("Player already finished their turn.")
+        expect(result.errorMessage).toBe("Player already finished their turn.");
       }
     });
 
@@ -291,62 +330,92 @@ describe("Qwixx Logic integration tests:", () => {
       testGame.endTurn("test-player2");
       expect(mockPlayer2.hasSubmittedChoice).toBeTruthy();
     });
+
+    test("non-active player can mark a number equal to the sum of the white dice", () => {
+      testGame.rollDice();
+      const res = testGame.makeMove("test-player2", "red", 5)
+
+      if(!res.success){
+        throw new Error("Marking a number equal to sum of white dice should be sucessful.")
+      }
+
+      if(res.gameEnd){
+        throw new Error("Game shouldn't have ended.")
+      }
+
+      expect(res.success).toBeTruthy()
+      expect(res.data.players["test-player2"].hasSubmittedChoice).toBeTruthy()
+    })
+
+    test("non-active player marking a number that doesn't equal to the sum of the white dice should return an error", () => {
+      testGame.rollDice();
+      const res = testGame.makeMove("test-player2", "red", 6)
+      if(res.success){
+        throw new Error("Marking a number that doesnt' equal sum of white dice should fail.")
+      }
+
+      expect(res.success).toBeFalsy()
+      expect(res.errorMessage).toBe("Number selected doesn't equal to sum of white dice.")
+    })
   });
 
   describe("end turn tests", () => {
     test("active player can end their turn", () => {
-      testGame.rollDice()
-      const result = testGame.endTurn("test-player1")
-      expect(result.success).toBeTruthy()
-      if (result.success) {
-        const player1State = result.data?.players["test-player1"]
-        expect(player1State?.hasSubmittedChoice).toBeTruthy()
+      testGame.rollDice();
+      const result = testGame.endTurn("test-player1");
+      expect(result.success).toBeTruthy();
+      if (result.success && !result.gameEnd) {
+        const player1State = result.data.players["test-player1"];
+        expect(player1State?.hasSubmittedChoice).toBeTruthy();
       }
-    })
+    });
 
     test("non-active player can end their turn without penalty", () => {
-      testGame.rollDice()
-      const result = testGame.endTurn("test-player2")
-      expect(result.success).toBeTruthy()
-      if (result.success) {
-        const player2State = result.data?.players["test-player2"]
-        expect(player2State?.hasSubmittedChoice).toBeTruthy()
-        expect(player2State?.gameCard.penalties).not.toEqual([1,])
+      testGame.rollDice();
+      const result = testGame.endTurn("test-player2");
+      expect(result.success).toBeTruthy();
+      if (result.success && !result.gameEnd) {
+        const player2State = result.data.players["test-player2"];
+        expect(player2State?.hasSubmittedChoice).toBeTruthy();
+        expect(player2State?.gameCard.penalties).not.toEqual([1]);
       }
-    })
+    });
 
     it("doesn't add a penalty to the active player when they marked a number and end their turn", () => {
-      testGame.rollDice()
+      testGame.rollDice();
       const diceResult = testGame.rollDice();
-      const whiteDiceSum = diceResult.diceValues.white1 + diceResult.diceValues.white2;
+      const whiteDiceSum =
+        diceResult.diceValues.white1 + diceResult.diceValues.white2;
       testGame.makeMove("test-player1", "red", whiteDiceSum);
 
-      const result = testGame.endTurn("test-player1")
-      expect(result.success).toBeTruthy()
-      if (result.success) {
-        const player1State = result.data?.players["test-player1"]
-        expect(player1State?.gameCard.penalties).not.toEqual([1,])
+      const result = testGame.endTurn("test-player1");
+      expect(result.success).toBeTruthy();
+      if (result.success && !result.gameEnd) {
+        const player1State = result.data.players["test-player1"];
+        expect(player1State?.gameCard.penalties).not.toEqual([1]);
       }
-    })
+    });
 
     it("adds a penalty to the active player if they end turn without marking a number", () => {
-      testGame.rollDice()
-      const result = testGame.endTurn("test-player1")
-      expect(result.success).toBeTruthy()
-      if (result.success) {
-        const player1State = result.data?.players["test-player1"]
-        expect(player1State?.gameCard.penalties).toEqual([1,])
+      testGame.rollDice();
+      const result = testGame.endTurn("test-player1");
+      expect(result.success).toBeTruthy();
+      if (result.success && !result.gameEnd) {
+        const player1State = result.data.players["test-player1"];
+        expect(player1State?.gameCard.penalties).toEqual([1]);
       }
-    })
+    });
 
     it("returns an error if player has already end their turn", () => {
-      testGame.rollDice()
-      testGame.endTurn("test-player1")
-      const result = testGame.endTurn("test-player1")
-      expect(result.success).toBeFalsy()
+      testGame.rollDice();
+      testGame.endTurn("test-player1");
+      const result = testGame.endTurn("test-player1");
+      expect(result.success).toBeFalsy();
       if (!result.success) {
-        expect(result.errorMessage).toBe("Player has already ended their turn.")
+        expect(result.errorMessage).toBe(
+          "Player has already ended their turn."
+        );
       }
-    })
-  })
+    });
+  });
 });

--- a/server/src/tests/services/QwixxLogic.integration.test.ts
+++ b/server/src/tests/services/QwixxLogic.integration.test.ts
@@ -438,4 +438,28 @@ describe("Qwixx Logic integration tests:", () => {
     testGame.rollDice();
     expect(() => testGame.endTurn("player3")).toThrow("Player not found");
   });
+
+  describe.only("Process Penalty test", () => {
+    it("should add a penalty to the player and mark them as submitted", () => {
+      testGame.rollDice()
+      const res = testGame.processPenalty("test-player1");
+
+      if(!res.success || res.gameEnd){
+        throw new Error()
+      }
+      expect(res.success).toBeTruthy();
+      
+      expect(res.data.players["test-player1"].gameCard.penalties).toEqual([1])
+      expect(res.data.players["test-player1"].hasSubmittedChoice).toBeTruthy()
+    });
+
+    test.todo("Can't add more than one penalty per round")
+
+    it("should throw an error if player not found", () => {
+      testGame.rollDice()
+      expect(() => testGame.processPenalty("player3")).toThrow(
+        "Player not found"
+      );
+    });
+  })
 });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -5,6 +5,7 @@ import Dice from "../../models/DiceClass";
 import { DiceColour } from "../../enums/DiceColours";
 import SixSidedDie from "../../models/SixSidedDieClass";
 import { rowColour } from "../../enums/rowColours";
+import { mockSixSidedDice } from "./__mocks__/QwixxLogicTestMocks";
 
 const MockedGameCardClass = qwixxBaseGameCard as jest.Mocked<
   typeof qwixxBaseGameCard
@@ -18,9 +19,8 @@ player1Mock.markNumber = jest.fn().mockReturnValue(true);
 const player2Mock = new Player("player2", gameCardMock2) as jest.Mocked<Player>;
 player2Mock.markNumber = jest.fn().mockReturnValue(true);
 
-const MockedDie = SixSidedDie as jest.Mocked<typeof SixSidedDie>;
 const MockedDiceClass = Dice as jest.Mocked<typeof Dice>;
-const fakeDice = new MockedDiceClass(MockedDie);
+const fakeDice = new MockedDiceClass(mockSixSidedDice);
 jest.spyOn(fakeDice, "diceValues", "get").mockReturnValue({
   [DiceColour.White1]: 5,
   [DiceColour.White2]: 5,

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -162,6 +162,7 @@ describe("Qwixx Logic tests", () => {
       const player1AddPenaltySpy = jest.spyOn(gameCardMock1, "addPenalty");
       const player1MarkSubmittedSpy = jest.spyOn(player1Mock, "markSubmitted");
 
+      testGame.rollDice()
       testGame.processPenalty("player1");
 
       expect(player1AddPenaltySpy).toHaveBeenCalledTimes(1);
@@ -214,24 +215,14 @@ describe("Qwixx Logic tests", () => {
 
     test("passMove method should be called if valid", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      console.log("submission count before:", player1Mock.submissionCount);
 
       jest.spyOn(player1Mock, "submissionCount", "get").mockReturnValue(0);
-
-      if (player1Mock) {
-        jest.spyOn(player1Mock, "passMove");
-      }
+      jest.spyOn(player1Mock, "hasSubmittedChoice", "get").mockReturnValueOnce(false)
+      jest.spyOn(player1Mock, "passMove");
 
       testGame.rollDice();
-      console.log(
-        "expect submission count to be 0",
-        player1Mock.submissionCount
-      );
       const res = testGame.passMove("player1");
-      console.log(
-        "submission count should be increased after passMove",
-        player1Mock.submissionCount
-      );
+      
       expect(player1Mock.passMove).toHaveBeenCalled();
       expect(res.success).toBeTruthy();
     });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -93,25 +93,6 @@ describe("Qwixx Logic tests", () => {
   });
 
   describe("passMove method tests", () => {
-    //TODO: Should be covered in integration test
-    test("Can't pass turn if a dice hasn't been rolled", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      const res = testGame.passMove("player1");
-
-      expect(res.success).toBeFalsy();
-
-      if (!res.success) {
-        expect(res.errorMessage).toBe("Dice hasn't been rolled yet.");
-      }
-    });
-
-    //TODO: Should be covered in integration test
-    test("should throw an error if player not found", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      testGame.rollDice();
-      expect(() => testGame.passMove("player3")).toThrow("Player not found.");
-    });
-
     test("passMove method should be called if valid", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
 

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -247,70 +247,130 @@ describe("Qwixx Logic tests", () => {
   // TODO: This should be combined with the game end phase test.
   describe("Calculate all players' score", () => {
     it("Can get back all players' score", () => {
-      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(73)
-      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(68)
-
-      const expected = {
-        player1: 73,
-        player2: 68,
+      const player1Scores = {
+          penalties: 0,
+          total: 78,
+          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
       }
 
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice)
-      const res = testGame.calculateScores()
+      const player2Scores = {
+          penalties: 0,
+          total: 66,
+          subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
+      }
 
-      expect(res).toEqual(expected)
-    })
+      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(player1Scores);
+      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(player2Scores);
+
+      const expected = [
+        {
+          name: "player1",
+          ...player1Scores
+        },
+        {
+          name: "player2",
+          ...player2Scores
+        },
+      ];
+
+      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+      const res = testGame.collectPlayersScores();
+
+      expect(res).toEqual(expected);
+    });
 
     it("Can determine the winner", () => {
-      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(73)
-      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(68)
+      const player1Scores = {
+          penalties: 0,
+          total: 78,
+          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+      }
 
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice)
-      const res = testGame.determineWinner()
+      const player2Scores = {
+          penalties: 0,
+          total: 66,
+          subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
+      }
 
-      expect(res).toEqual(["player1"])
-    })
+      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(player1Scores);
+      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(player2Scores);
+
+      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+      const res = testGame.determineWinner();
+
+      expect(res.winners).toEqual(["player1"]);
+    });
 
     it("Can determine multiple winners", () => {
-      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(73)
-      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(73)
+      const player1Scores = {
+          penalties: 0,
+          total: 78,
+          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+      }
 
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice)
-      const res = testGame.determineWinner()
+      const player2Scores = {
+          penalties: 0,
+          total: 78,
+          subtotal: { red: 0, yellow: 78, green: 0, blue: 0 },
+      }
 
-      expect(res).toEqual(["player1", "player2"])
-    })
-  })
+      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(player1Scores);
+      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(player2Scores);
+
+      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+      const res = testGame.determineWinner();
+
+      expect(res.winners).toEqual(["player1", "player2"]);
+    });
+  });
 
   describe("Game end:", () => {
     it("Can determine the game has ended when 2 rows are locked", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice)
-      testGame.rollDice()
+      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
+      testGame.rollDice();
 
-      gameCardMock1.lockRow = jest.fn()
+      gameCardMock1.lockRow = jest
+        .fn()
         .mockReturnValueOnce({ success: true, lockedRow: rowColour.Red })
-        .mockReturnValueOnce({ success: true, lockedRow: rowColour.Yellow })
+        .mockReturnValueOnce({ success: true, lockedRow: rowColour.Yellow });
 
-      gameCardMock1.calculateScores = jest.fn()
-        .mockReturnValueOnce({ penalties: 0, total: 48, subtotal: { red: 12, yellow: 12, green: 12, blue: 12 } })
-      gameCardMock2.calculateScores = jest.fn()
-        .mockReturnValueOnce({ penalties: 0, total: 36, subtotal: { red: 12, yellow: 12, green: 12, blue: 0 } })
-      testGame.lockRow("player1", "red")
-      testGame.lockRow("player1", "yellow")
+      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce({
+        penalties: 0,
+        total: 48,
+        subtotal: { red: 12, yellow: 12, green: 12, blue: 12 },
+      });
+      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce({
+        penalties: 0,
+        total: 36,
+        subtotal: { red: 12, yellow: 12, green: 12, blue: 0 },
+      });
+      testGame.lockRow("player1", "red");
+      testGame.lockRow("player1", "yellow");
 
-      jest.spyOn(player1Mock, "hasSubmittedChoice", "get").mockReturnValueOnce(false).mockReturnValueOnce(true)
-      jest.spyOn(player2Mock, "hasSubmittedChoice", "get").mockReturnValueOnce(true)
-      const res = testGame.endTurn("player1")
+      jest
+        .spyOn(player1Mock, "hasSubmittedChoice", "get")
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true);
+      jest
+        .spyOn(player2Mock, "hasSubmittedChoice", "get")
+        .mockReturnValueOnce(true);
+      const res = testGame.endTurn("player1");
 
-      console.log(res)
+      console.log(res);
       if (res.success) {
-        expect(res.data).toEqual(["player1"])
+        expect(res.data).toEqual(["player1"]);
       }
-    })
+    });
 
-    it.todo("Can determine the game has ended when more than 2 rows are locked")
-    it.todo("Can determine the game has ended when a player has 4 penalties")
-    it.todo("Can determine the game hasn't ended if at least 2 rows aren't locked")
-    it.todo("Can determine the game hasn't ended if 4 penalties haven't been accrued by a player")
-  })
+    it.todo(
+      "Can determine the game has ended when more than 2 rows are locked"
+    );
+    it.todo("Can determine the game has ended when a player has 4 penalties");
+    it.todo(
+      "Can determine the game hasn't ended if at least 2 rows aren't locked"
+    );
+    it.todo(
+      "Can determine the game hasn't ended if 4 penalties haven't been accrued by a player"
+    );
+  });
 });

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -72,7 +72,7 @@ describe("Qwixx Logic tests", () => {
       const res = testGame.makeMove("player2", "red", 9);
       if (!res.success) {
         expect(res.success).toBeFalsy();
-        expect(res.error).toEqual(
+        expect(res.errorMessage).toEqual(
           "Number selected doesn't equal to sum of white dice."
         );
       }
@@ -95,7 +95,7 @@ describe("Qwixx Logic tests", () => {
       const res = testGame.makeMove("player1", "red", 9);
       if (!res.success) {
         expect(res.success).toBeFalsy();
-        expect(res.error).toEqual(
+        expect(res.errorMessage).toEqual(
           "Number selected doesn't equal to sum of white dice."
         );
       }
@@ -117,7 +117,7 @@ describe("Qwixx Logic tests", () => {
         const res = testGame.makeMove("player1", row, num);
         if (!res.success) {
           expect(res.success).toBeFalsy();
-          expect(res.error).toEqual(
+          expect(res.errorMessage).toEqual(
             "Number selected doesn't equal to sum of white die and coloured die."
           );
         }
@@ -191,8 +191,8 @@ describe("Qwixx Logic tests", () => {
       const res = testGame.endTurn("player1");
 
       expect(res.success).toBeFalsy();
-      if (!res.success) {
-        expect(res.errorMessage).toBe("Dice hasn't been rolled yet.");
+      if(!res.success){
+      expect(res.errorMessage).toBe("Dice hasn't been rolled yet.");
       }
     });
 
@@ -208,9 +208,9 @@ describe("Qwixx Logic tests", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       const res = testGame.passMove("player1");
 
-      expect(res.isValid).toBeFalsy();
+      expect(res.success).toBeFalsy();
 
-      if (!res.isValid) {
+      if (!res.success) {
         expect(res.errorMessage).toBe("Dice hasn't been rolled yet.");
       }
     });
@@ -242,7 +242,7 @@ describe("Qwixx Logic tests", () => {
         player1Mock.submissionCount
       );
       expect(player1Mock.passMove).toHaveBeenCalled();
-      expect(res.isValid).toBeTruthy();
+      expect(res.success).toBeTruthy();
     });
   });
 
@@ -250,32 +250,28 @@ describe("Qwixx Logic tests", () => {
   describe("Calculate all players' score", () => {
     it("Can get back all players' score", () => {
       const player1Scores = {
-        penalties: 0,
-        total: 78,
-        subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
-      };
+          penalties: 0,
+          total: 78,
+          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+      }
 
       const player2Scores = {
-        penalties: 0,
-        total: 66,
-        subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
-      };
+          penalties: 0,
+          total: 66,
+          subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
+      }
 
-      gameCardMock1.calculateScores = jest
-        .fn()
-        .mockReturnValueOnce(player1Scores);
-      gameCardMock2.calculateScores = jest
-        .fn()
-        .mockReturnValueOnce(player2Scores);
+      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(player1Scores);
+      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(player2Scores);
 
       const expected = [
         {
           name: "player1",
-          ...player1Scores,
+          ...player1Scores
         },
         {
           name: "player2",
-          ...player2Scores,
+          ...player2Scores
         },
       ];
 
@@ -287,23 +283,19 @@ describe("Qwixx Logic tests", () => {
 
     it("Can determine the winner", () => {
       const player1Scores = {
-        penalties: 0,
-        total: 78,
-        subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
-      };
+          penalties: 0,
+          total: 78,
+          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+      }
 
       const player2Scores = {
-        penalties: 0,
-        total: 66,
-        subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
-      };
+          penalties: 0,
+          total: 66,
+          subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
+      }
 
-      gameCardMock1.calculateScores = jest
-        .fn()
-        .mockReturnValueOnce(player1Scores);
-      gameCardMock2.calculateScores = jest
-        .fn()
-        .mockReturnValueOnce(player2Scores);
+      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(player1Scores);
+      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(player2Scores);
 
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       const res = testGame.determineWinner();
@@ -313,23 +305,19 @@ describe("Qwixx Logic tests", () => {
 
     it("Can determine multiple winners", () => {
       const player1Scores = {
-        penalties: 0,
-        total: 78,
-        subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
-      };
+          penalties: 0,
+          total: 78,
+          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+      }
 
       const player2Scores = {
-        penalties: 0,
-        total: 78,
-        subtotal: { red: 0, yellow: 78, green: 0, blue: 0 },
-      };
+          penalties: 0,
+          total: 78,
+          subtotal: { red: 0, yellow: 78, green: 0, blue: 0 },
+      }
 
-      gameCardMock1.calculateScores = jest
-        .fn()
-        .mockReturnValueOnce(player1Scores);
-      gameCardMock2.calculateScores = jest
-        .fn()
-        .mockReturnValueOnce(player2Scores);
+      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(player1Scores);
+      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(player2Scores);
 
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       const res = testGame.determineWinner();

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -164,7 +164,7 @@ describe("Qwixx Logic tests", () => {
 
       testGame.processPenalty("player1");
 
-      expect(player1AddPenaltySpy).toHaveBeenCalled();
+      expect(player1AddPenaltySpy).toHaveBeenCalledTimes(1);
       expect(player1MarkSubmittedSpy).toHaveBeenCalled();
     });
 
@@ -173,15 +173,6 @@ describe("Qwixx Logic tests", () => {
       expect(() => testGame.processPenalty("player3")).toThrow(
         "Player not found"
       );
-    });
-
-    it("should add a penalty to the players gamecard", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-
-      const addPenaltySpy = jest.spyOn(player1Mock.gameCard, "addPenalty");
-      testGame.processPenalty("player1");
-
-      expect(addPenaltySpy).toHaveBeenCalled();
     });
   });
 

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -191,7 +191,9 @@ describe("Qwixx Logic tests", () => {
       const res = testGame.endTurn("player1");
 
       expect(res.success).toBeFalsy();
-      expect(res.errorMessage).toBe("Dice hasn't been rolled yet.");
+      if (!res.success) {
+        expect(res.errorMessage).toBe("Dice hasn't been rolled yet.");
+      }
     });
 
     test("should throw an error if player not found", () => {
@@ -248,28 +250,32 @@ describe("Qwixx Logic tests", () => {
   describe("Calculate all players' score", () => {
     it("Can get back all players' score", () => {
       const player1Scores = {
-          penalties: 0,
-          total: 78,
-          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
-      }
+        penalties: 0,
+        total: 78,
+        subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+      };
 
       const player2Scores = {
-          penalties: 0,
-          total: 66,
-          subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
-      }
+        penalties: 0,
+        total: 66,
+        subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
+      };
 
-      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(player1Scores);
-      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(player2Scores);
+      gameCardMock1.calculateScores = jest
+        .fn()
+        .mockReturnValueOnce(player1Scores);
+      gameCardMock2.calculateScores = jest
+        .fn()
+        .mockReturnValueOnce(player2Scores);
 
       const expected = [
         {
           name: "player1",
-          ...player1Scores
+          ...player1Scores,
         },
         {
           name: "player2",
-          ...player2Scores
+          ...player2Scores,
         },
       ];
 
@@ -281,19 +287,23 @@ describe("Qwixx Logic tests", () => {
 
     it("Can determine the winner", () => {
       const player1Scores = {
-          penalties: 0,
-          total: 78,
-          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
-      }
+        penalties: 0,
+        total: 78,
+        subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+      };
 
       const player2Scores = {
-          penalties: 0,
-          total: 66,
-          subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
-      }
+        penalties: 0,
+        total: 66,
+        subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
+      };
 
-      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(player1Scores);
-      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(player2Scores);
+      gameCardMock1.calculateScores = jest
+        .fn()
+        .mockReturnValueOnce(player1Scores);
+      gameCardMock2.calculateScores = jest
+        .fn()
+        .mockReturnValueOnce(player2Scores);
 
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       const res = testGame.determineWinner();
@@ -303,19 +313,23 @@ describe("Qwixx Logic tests", () => {
 
     it("Can determine multiple winners", () => {
       const player1Scores = {
-          penalties: 0,
-          total: 78,
-          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
-      }
+        penalties: 0,
+        total: 78,
+        subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+      };
 
       const player2Scores = {
-          penalties: 0,
-          total: 78,
-          subtotal: { red: 0, yellow: 78, green: 0, blue: 0 },
-      }
+        penalties: 0,
+        total: 78,
+        subtotal: { red: 0, yellow: 78, green: 0, blue: 0 },
+      };
 
-      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(player1Scores);
-      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(player2Scores);
+      gameCardMock1.calculateScores = jest
+        .fn()
+        .mockReturnValueOnce(player1Scores);
+      gameCardMock2.calculateScores = jest
+        .fn()
+        .mockReturnValueOnce(player2Scores);
 
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       const res = testGame.determineWinner();
@@ -356,9 +370,8 @@ describe("Qwixx Logic tests", () => {
         .mockReturnValueOnce(true);
       const res = testGame.endTurn("player1");
 
-      console.log(res);
-      if (res.success) {
-        expect(res.data).toEqual(["player1"]);
+      if (res.success && res.gameEnd) {
+        expect(res.data.winners).toEqual(["player1"]);
       }
     });
 

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -78,7 +78,7 @@ describe("Qwixx Logic tests", () => {
   });
 
   describe("processPenalthy method tests", () => {
-    //TODO: Should be covered in integration test
+    //TODO: Should rename this description
     it("should add a penalty to the player and mark them as submitted", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       const player1AddPenaltySpy = jest.spyOn(gameCardMock1, "addPenalty");
@@ -89,14 +89,6 @@ describe("Qwixx Logic tests", () => {
 
       expect(player1AddPenaltySpy).toHaveBeenCalledTimes(1);
       expect(player1MarkSubmittedSpy).toHaveBeenCalled();
-    });
-
-    //TODO: Should be covered in integration test
-    it("should throw an error if player not found", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      expect(() => testGame.processPenalty("player3")).toThrow(
-        "Player not found"
-      );
     });
   });
 

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -191,8 +191,8 @@ describe("Qwixx Logic tests", () => {
       const res = testGame.endTurn("player1");
 
       expect(res.success).toBeFalsy();
-      if(!res.success){
-      expect(res.errorMessage).toBe("Dice hasn't been rolled yet.");
+      if (!res.success) {
+        expect(res.errorMessage).toBe("Dice hasn't been rolled yet.");
       }
     });
 
@@ -250,28 +250,32 @@ describe("Qwixx Logic tests", () => {
   describe("Calculate all players' score", () => {
     it("Can get back all players' score", () => {
       const player1Scores = {
-          penalties: 0,
-          total: 78,
-          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
-      }
+        penalties: 0,
+        total: 78,
+        subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+      };
 
       const player2Scores = {
-          penalties: 0,
-          total: 66,
-          subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
-      }
+        penalties: 0,
+        total: 66,
+        subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
+      };
 
-      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(player1Scores);
-      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(player2Scores);
+      gameCardMock1.calculateScores = jest
+        .fn()
+        .mockReturnValueOnce(player1Scores);
+      gameCardMock2.calculateScores = jest
+        .fn()
+        .mockReturnValueOnce(player2Scores);
 
       const expected = [
         {
           name: "player1",
-          ...player1Scores
+          ...player1Scores,
         },
         {
           name: "player2",
-          ...player2Scores
+          ...player2Scores,
         },
       ];
 
@@ -283,19 +287,23 @@ describe("Qwixx Logic tests", () => {
 
     it("Can determine the winner", () => {
       const player1Scores = {
-          penalties: 0,
-          total: 78,
-          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
-      }
+        penalties: 0,
+        total: 78,
+        subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+      };
 
       const player2Scores = {
-          penalties: 0,
-          total: 66,
-          subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
-      }
+        penalties: 0,
+        total: 66,
+        subtotal: { red: 0, yellow: 66, green: 0, blue: 0 },
+      };
 
-      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(player1Scores);
-      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(player2Scores);
+      gameCardMock1.calculateScores = jest
+        .fn()
+        .mockReturnValueOnce(player1Scores);
+      gameCardMock2.calculateScores = jest
+        .fn()
+        .mockReturnValueOnce(player2Scores);
 
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       const res = testGame.determineWinner();
@@ -305,19 +313,23 @@ describe("Qwixx Logic tests", () => {
 
     it("Can determine multiple winners", () => {
       const player1Scores = {
-          penalties: 0,
-          total: 78,
-          subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
-      }
+        penalties: 0,
+        total: 78,
+        subtotal: { red: 78, yellow: 0, green: 0, blue: 0 },
+      };
 
       const player2Scores = {
-          penalties: 0,
-          total: 78,
-          subtotal: { red: 0, yellow: 78, green: 0, blue: 0 },
-      }
+        penalties: 0,
+        total: 78,
+        subtotal: { red: 0, yellow: 78, green: 0, blue: 0 },
+      };
 
-      gameCardMock1.calculateScores = jest.fn().mockReturnValueOnce(player1Scores);
-      gameCardMock2.calculateScores = jest.fn().mockReturnValueOnce(player2Scores);
+      gameCardMock1.calculateScores = jest
+        .fn()
+        .mockReturnValueOnce(player1Scores);
+      gameCardMock2.calculateScores = jest
+        .fn()
+        .mockReturnValueOnce(player2Scores);
 
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       const res = testGame.determineWinner();

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -63,87 +63,6 @@ describe("Qwixx Logic tests", () => {
         "Player not found"
       );
     });
-
-    test("non-active player marking a number that doesn't equal the sum of white dice should return error object", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-
-      testGame.rollDice();
-
-      const res = testGame.makeMove("player2", "red", 9);
-      if (!res.success) {
-        expect(res.success).toBeFalsy();
-        expect(res.errorMessage).toEqual(
-          "Number selected doesn't equal to sum of white dice."
-        );
-      }
-    });
-
-    test("non-active player can mark a number equal to the sum of the white dice", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-
-      testGame.rollDice();
-      testGame.makeMove("player2", "red", 10);
-
-      expect(player2Mock.markNumber).toHaveBeenCalledWith("red", 10);
-      expect(player2Mock.markNumber).toHaveBeenCalledTimes(1);
-    });
-
-    test("active player marking a number that doesn't equal the sum of white dice should throw an error", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      testGame.rollDice();
-
-      const res = testGame.makeMove("player1", "red", 9);
-      if (!res.success) {
-        expect(res.success).toBeFalsy();
-        expect(res.errorMessage).toEqual(
-          "Number selected doesn't equal to sum of white dice."
-        );
-      }
-    });
-
-    test.each([
-      ["red", 9],
-      ["yellow", 9],
-      ["green", 9],
-      ["blue", 9],
-    ])(
-      "active-player marking a number that doesn't equal the sum of a white dice and a %s dice should throw an error",
-      (row, num) => {
-        jest.spyOn(player1Mock, "submissionCount", "get").mockReturnValue(1);
-        const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-
-        testGame.rollDice();
-
-        const res = testGame.makeMove("player1", row, num);
-        if (!res.success) {
-          expect(res.success).toBeFalsy();
-          expect(res.errorMessage).toEqual(
-            "Number selected doesn't equal to sum of white die and coloured die."
-          );
-        }
-      }
-    );
-
-    test.each([
-      ["red", 10],
-      ["yellow", 10],
-      ["green", 10],
-      ["blue", 10],
-    ])(
-      "active-player marking a number that equals the sum of a white dice and a %s dice shouldn't throw an error",
-      (row, num) => {
-        jest.spyOn(player1Mock, "submissionCount", "get").mockReturnValue(1);
-        const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-
-        testGame.rollDice();
-
-        expect(() => {
-          testGame.makeMove("player1", row, num);
-        }).not.toThrow(
-          "Number selected doesn't equal to sum of white die and coloured die."
-        );
-      }
-    );
   });
 
   describe("rollDice method tests", () => {
@@ -154,9 +73,12 @@ describe("Qwixx Logic tests", () => {
       jest.spyOn(gameCardMock1, "hasAvailableMoves").mockReturnValueOnce(true);
       expect(res.hasAvailableMoves).toBeTruthy();
     });
+
+    test.todo("no available moves")
   });
 
   describe("processPenalthy method tests", () => {
+    //TODO: Should be covered in integration test
     it("should add a penalty to the player and mark them as submitted", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       const player1AddPenaltySpy = jest.spyOn(gameCardMock1, "addPenalty");
@@ -169,6 +91,7 @@ describe("Qwixx Logic tests", () => {
       expect(player1MarkSubmittedSpy).toHaveBeenCalled();
     });
 
+    //TODO: Should be covered in integration test
     it("should throw an error if player not found", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       expect(() => testGame.processPenalty("player3")).toThrow(
@@ -178,6 +101,7 @@ describe("Qwixx Logic tests", () => {
   });
 
   describe("endTurn method tests", () => {
+    //TODO: Should be covered in integration test
     test("Can't end a turn if a dice hasn't been rolled", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       const res = testGame.endTurn("player1");
@@ -188,6 +112,7 @@ describe("Qwixx Logic tests", () => {
       }
     });
 
+    //TODO: SHould be covered in integration test
     test("should throw an error if player not found", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       testGame.rollDice();
@@ -196,6 +121,7 @@ describe("Qwixx Logic tests", () => {
   });
 
   describe("passMove method tests", () => {
+    //TODO: Should be covered in integration test
     test("Can't pass turn if a dice hasn't been rolled", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       const res = testGame.passMove("player1");
@@ -207,6 +133,7 @@ describe("Qwixx Logic tests", () => {
       }
     });
 
+    //TODO: Should be covered in integration test
     test("should throw an error if player not found", () => {
       const testGame = new QwixxLogic(playersArrayMock, fakeDice);
       testGame.rollDice();
@@ -228,6 +155,7 @@ describe("Qwixx Logic tests", () => {
     });
   });
 
+  // NOTE: Should keep these as unit tests
   // TODO: This should be combined with the game end phase test.
   describe("Calculate all players' score", () => {
     it("Can get back all players' score", () => {

--- a/server/src/tests/services/QwixxLogic.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic.unit.test.ts
@@ -100,26 +100,6 @@ describe("Qwixx Logic tests", () => {
     });
   });
 
-  describe("endTurn method tests", () => {
-    //TODO: Should be covered in integration test
-    test("Can't end a turn if a dice hasn't been rolled", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      const res = testGame.endTurn("player1");
-
-      expect(res.success).toBeFalsy();
-      if (!res.success) {
-        expect(res.errorMessage).toBe("Dice hasn't been rolled yet.");
-      }
-    });
-
-    //TODO: SHould be covered in integration test
-    test("should throw an error if player not found", () => {
-      const testGame = new QwixxLogic(playersArrayMock, fakeDice);
-      testGame.rollDice();
-      expect(() => testGame.endTurn("player3")).toThrow("Player not found.");
-    });
-  });
-
   describe("passMove method tests", () => {
     //TODO: Should be covered in integration test
     test("Can't pass turn if a dice hasn't been rolled", () => {

--- a/server/src/tests/services/QwixxLogic2.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic2.unit.test.ts
@@ -157,4 +157,49 @@ describe("Game end:", () => {
     expect(res.gameEnd).toBeFalsy();
     expect(res.data.hasRolled).toBeFalsy();
   });
+
+  test("Players can't do any actions if game has ended", () => {
+    const testGame = new QwixxLogic([player1Mock, player2Mock], diceMock);
+    testGame.rollDice();
+
+    testGame.lockRow("Player1", "red");
+    testGame.lockRow("Player2", "yellow");
+
+    jest
+      .spyOn(player1Mock, "hasSubmittedChoice", "get")
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    const res = testGame.endTurn("Player1");
+
+    if (!res.success || !res.gameEnd) {
+      throw new Error("Result is not a game-end state");
+    }
+
+    const makeMoveRes = testGame.makeMove("Player1", "red", 10)
+
+    if (makeMoveRes.success) {
+      throw new Error("Can't make a move if game has ended");
+    }
+
+    expect(makeMoveRes.success).toBeFalsy()
+    expect(makeMoveRes.errorMessage).toBe("Can't perform action. Game has already ended.")
+
+    const endTurnRes = testGame.endTurn("Player1")
+
+    if (endTurnRes.success) {
+      throw new Error("Can't end a turn if game has ended");
+    }
+
+    expect(endTurnRes.success).toBeFalsy()
+    expect(endTurnRes.errorMessage).toBe("Can't perform action. Game has already ended.")
+
+    const processPenaltyRes = testGame.processPenalty("Player1")
+
+    if (processPenaltyRes.success) {
+      throw new Error("Can't process a penalty if game has ended");
+    }
+
+    expect(processPenaltyRes.success).toBeFalsy()
+    expect(processPenaltyRes.errorMessage).toBe("Can't perform action. Game has already ended.")
+  })
 });

--- a/server/src/tests/services/QwixxLogic2.unit.test.ts
+++ b/server/src/tests/services/QwixxLogic2.unit.test.ts
@@ -1,0 +1,160 @@
+import QwixxLogic from "../../services/QwixxLogic";
+import {
+  GameCardLockedRedRowMock,
+  GameCardLockedYellowRowMock,
+  player1Mock,
+  player2Mock,
+  diceMock,
+} from "../models/__mocks__/MockedInterfaces";
+
+describe.skip("Game Actions", () => {
+  it("should call the markNumber method with correct args", () => {
+    const testGame = new QwixxLogic([player1Mock, player2Mock], diceMock);
+    testGame.rollDice();
+    testGame.makeMove("Player1", "red", 10);
+
+    expect(player1Mock.markNumber).toHaveBeenCalledWith("red", 10);
+    expect(player1Mock.markNumber).toHaveBeenCalledTimes(1);
+  });
+
+  it("should throw an error if the player isn't found", () => {
+    const testGame = new QwixxLogic([player1Mock, player2Mock], diceMock);
+    testGame.rollDice();
+
+    expect(() => testGame.makeMove("bad-player", "red", 2)).toThrow(
+      "Player not found"
+    );
+  });
+
+  test("non-active player marking a number that doesn't equal the sum of white dice should return error object", () => {
+    const testGame = new QwixxLogic([player1Mock, player2Mock], diceMock);
+
+    testGame.rollDice();
+
+    const res = testGame.makeMove("Player1", "red", 9);
+    if (!res.success) {
+      expect(res.success).toBeFalsy();
+      expect(res.errorMessage).toEqual(
+        "Number selected doesn't equal to sum of white dice."
+      );
+    }
+  });
+
+  test.only("non-active player can mark a number equal to the sum of the white dice", () => {
+    const testGame = new QwixxLogic([player1Mock, player2Mock], diceMock);
+
+    testGame.rollDice();
+    testGame.makeMove("Player2", "red", 10);
+
+    expect(player2Mock.markNumber).toHaveBeenCalledWith("red", 10);
+    expect(player2Mock.markNumber).toHaveBeenCalledTimes(1);
+  });
+});
+describe("Game end:", () => {
+  it("Can determine the game has ended when 2 rows are locked", () => {
+    const testGame = new QwixxLogic([player1Mock, player2Mock], diceMock);
+    testGame.rollDice();
+
+    testGame.lockRow("Player1", "red");
+    testGame.lockRow("Player2", "yellow");
+
+    jest
+      .spyOn(player1Mock, "hasSubmittedChoice", "get")
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    const res = testGame.endTurn("Player1");
+
+    if (!res.success || !res.gameEnd) {
+      throw new Error("Result is not a game-end state");
+    }
+
+    expect(res.data.winners).toEqual(["Player1"]);
+  });
+
+  it("Can determine the game has ended when more than 2 rows are locked", () => {
+    const testGame = new QwixxLogic([player1Mock, player2Mock], diceMock);
+    testGame.rollDice();
+
+    testGame.lockRow("Player1", "red");
+    testGame.lockRow("Player2", "yellow");
+
+    jest
+      .spyOn(player1Mock, "hasSubmittedChoice", "get")
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    const res = testGame.endTurn("Player1");
+
+    if (!res.success || !res.gameEnd) {
+      throw new Error("Result is not a game-end state");
+    }
+
+    expect(res.data.winners).toEqual(["Player1"]);
+  });
+
+  it("Can determine the game has ended when a player has 4 penalties", () => {
+    jest
+      .spyOn(GameCardLockedRedRowMock, "penalties", "get")
+      .mockReturnValueOnce([1, 2, 3, 4]);
+
+    jest
+      .spyOn(player1Mock, "hasSubmittedChoice", "get")
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+
+    const testGame = new QwixxLogic([player1Mock, player2Mock], diceMock);
+    testGame.rollDice();
+
+    const res = testGame.processPenalty("Player1");
+
+    if (!res.success || !res.gameEnd) {
+      throw new Error("Result is not a game-end state");
+    }
+
+    expect(res.data.winners).toEqual(["Player1"]);
+  });
+
+  it("Can determine the game hasn't ended if at least 2 rows aren't locked", () => {
+    jest
+      .spyOn(player1Mock, "hasSubmittedChoice", "get")
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+
+    const testGame = new QwixxLogic([player1Mock, player2Mock], diceMock);
+    testGame.rollDice();
+
+    testGame.lockRow("Player1", "red");
+    const res = testGame.endTurn("Player1");
+
+    if (!res.success || res.gameEnd) {
+      throw new Error("Result is not successful");
+    }
+
+    expect(res.success).toBeTruthy();
+    expect(res.gameEnd).toBeFalsy();
+    expect(res.data.hasRolled).toBeFalsy();
+  });
+
+  it("Can determine the game hasn't ended if 4 penalties haven't been accrued by a player", () => {
+    jest
+      .spyOn(GameCardLockedRedRowMock, "penalties", "get")
+      .mockReturnValueOnce([1]);
+
+    jest
+      .spyOn(player1Mock, "hasSubmittedChoice", "get")
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+
+    const testGame = new QwixxLogic([player1Mock, player2Mock], diceMock);
+    testGame.rollDice();
+
+    const res = testGame.processPenalty("Player1");
+
+    if (!res.success || res.gameEnd) {
+      throw new Error("Result is not a game-end state");
+    }
+
+    expect(res.success).toBeTruthy();
+    expect(res.gameEnd).toBeFalsy();
+    expect(res.data.hasRolled).toBeFalsy();
+  });
+});

--- a/server/src/tests/services/__mocks__/QwixxLogicTestMocks.ts
+++ b/server/src/tests/services/__mocks__/QwixxLogicTestMocks.ts
@@ -1,0 +1,24 @@
+import IDie from "../../../models/IDie";
+import { DiceColour } from "../../../enums/DiceColours";
+
+function createDieMock(dieValue: number): IDie{
+    return {
+        get value(){
+            return dieValue
+        },
+        get active(){
+            return true;
+        },
+        rollDie: jest.fn().mockReturnValue(dieValue),
+        disable: jest.fn(),
+    }
+}
+
+export const mockSixSidedDice = {
+  [DiceColour.White1]: createDieMock(2),
+  [DiceColour.White2]: createDieMock(3),
+  [DiceColour.Red]: createDieMock(4),
+  [DiceColour.Yellow]: createDieMock(5),
+  [DiceColour.Green]: createDieMock(6),
+  [DiceColour.Blue]: createDieMock(1),
+};

--- a/server/src/tests/services/__mocks__/QwixxLogicTestMocks.ts
+++ b/server/src/tests/services/__mocks__/QwixxLogicTestMocks.ts
@@ -1,7 +1,7 @@
 import IDie from "../../../models/IDie";
 import { DiceColour } from "../../../enums/DiceColours";
 
-function createDieMock(dieValue: number): IDie{
+function createDieMock(dieValue: number): jest.Mocked<IDie>{
     return {
         get value(){
             return dieValue


### PR DESCRIPTION
# Description:
- This branch adds the game end check feature.
- Check out original issue #49 

# How:
- I added a new private method that checks if there are at least 2 locked rows or if any player has accrued 4 penalties.
- This check is made when the round has finished as part of "processPlayerSubmission()".
- makeMove(), processPenalty(), endTurn(), now returns 3 different types, one of them being the EndGameSummary. The types these 3 methods return is called "GameActionResult". 
- Simplified return types in QwixxLogic. 
- I created interfaces for the QwixxLogic, GameCard, Player, Dice, and Die classes.
- Used Dependency Injection for injecting Die classes into Dice.
- Client-side code now listens for a 'game_ended' event and currently displays the winner. This handling needs to be worked on.
- Removed some unit tests as they are covered by integration tests.
- makeMove(), processPenalty(), and endTurn() now call a validateGameActionPrequisite() method for basic checks before an action can be performed.

# Why:
- The check for the game end is made in processPlayerSubmission as the game can only end once all players have made their submissions for the round.
- makeMove(), processPenalty(), and endTurn() all currently result in a similar outcome, so their return types have been unified.
- Using interfaces as the types instead of the concrete implementation of classes makes the code more modular. It can also potentially make mocking easier because of dependency injection. We will need to refactor some of the test code. 
- As there was overlap between the integration tests and unit tests, I removed some of the test cases from the unit tests. We should now use the unit tests for edge cases and harder-to-test states like the end game. 
- As the game actions have similar prerequisites, it was better to extract them into a single method that can be re-used across all of them, making it easier to refactor in the future and to have more consistent error messages.